### PR TITLE
Add scene shell and save foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Run the development CLI:
 npm run dev
 ```
 
+Run with readable development-mode save data:
+
+```bash
+npm run dev -- --dev
+```
+
 Run the full local verification suite:
 
 ```bash

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,6 +2,7 @@
 
 ## Now
 
+- [ ] Complete [#17](https://github.com/hideyukiMORI/keyquest/issues/17): scene shell and save foundation.
 - [ ] Build [#2](https://github.com/hideyukiMORI/keyquest/issues/2): first interactive typing loop.
 - [ ] Define [#7](https://github.com/hideyukiMORI/keyquest/issues/7): local save-file shape for session history, XP, streaks, and settings.
 - [ ] Design [#11](https://github.com/hideyukiMORI/keyquest/issues/11): first home-position and finger-usage lesson sequence.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runApp } from "./app.js";
+
+const tempDirectories: string[] = [];
+
+describe("runApp", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+  });
+
+  it("renders the scene shell", async () => {
+    const output = await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(output).toContain("KeyQuest");
+    expect(output).toContain("Story");
+    expect(output).toContain("Status");
+    expect(output).toContain("Practice Preview");
+  });
+
+  it("marks development mode visibly", async () => {
+    const output = await runApp({
+      mode: "development",
+      saveDirectory: await createTempDirectory(),
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(output).toContain("DEV MODE");
+  });
+});
+
+async function createTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "keyquest-app-"));
+  tempDirectories.push(directory);
+  return directory;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,44 @@
+import { scoreTypingResult } from "./core/scoring.js";
+import type { SaveMode } from "./save/model.js";
+import { createSaveStore } from "./save/store.js";
+import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
+import { defaultScenes } from "./scenes/scenes.js";
+
+export type RunAppOptions = {
+  readonly mode: SaveMode;
+  readonly saveDirectory?: string;
+  readonly now?: Date;
+};
+
+export async function runApp(options: RunAppOptions): Promise<string> {
+  const now = options.now ?? new Date();
+  const saveStore = createSaveStore({
+    mode: options.mode,
+    directory: options.saveDirectory,
+  });
+  const save = await saveStore.loadOrCreate(now);
+  await saveStore.write(save);
+
+  const samplePrompt = "f j f j asdf jkl;";
+  const previewScore = scoreTypingResult({
+    expected: samplePrompt,
+    actual: samplePrompt,
+    startedAt: now,
+    completedAt: new Date(now.getTime() + 20_000),
+  });
+
+  const outputs = renderSceneSequence({
+    scenes: defaultScenes,
+    context: {
+      save,
+      mode: options.mode,
+      now,
+      practicePreview: {
+        prompt: samplePrompt,
+        score: previewScore,
+      },
+    },
+  });
+
+  return formatSceneSequence(outputs);
+}

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCliArgs } from "./args.js";
+
+describe("parseCliArgs", () => {
+  it("parses development mode aliases", () => {
+    expect(parseCliArgs(["--dev"]).devMode).toBe(true);
+    expect(parseCliArgs(["-dev"]).devMode).toBe(true);
+  });
+
+  it("parses save directory forms", () => {
+    expect(parseCliArgs(["--save-dir", "/tmp/keyquest"]).saveDirectory).toBe("/tmp/keyquest");
+    expect(parseCliArgs(["--save-dir=/tmp/keyquest"]).saveDirectory).toBe("/tmp/keyquest");
+  });
+
+  it("rejects unknown options", () => {
+    expect(() => parseCliArgs(["--mystery"])).toThrow("Unknown option");
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,38 @@
+export type CliOptions = {
+  readonly devMode: boolean;
+  readonly saveDirectory?: string;
+};
+
+export function parseCliArgs(args: readonly string[]): CliOptions {
+  let devMode = false;
+  let saveDirectory: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--dev" || arg === "-dev") {
+      devMode = true;
+      continue;
+    }
+
+    if (arg === "--save-dir") {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--save-dir requires a directory path");
+      }
+
+      saveDirectory = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--save-dir=")) {
+      saveDirectory = arg.slice("--save-dir=".length);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return { devMode, saveDirectory };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,18 @@
 #!/usr/bin/env node
 
-import { scoreTypingResult } from "./core/scoring.js";
+import { runApp } from "./app.js";
+import { parseCliArgs } from "./cli/args.js";
 
-const samplePrompt = "find the key, keep the rhythm, open the gate";
-const startedAt = new Date();
-const completedAt = new Date(startedAt.getTime() + 30_000);
-const score = scoreTypingResult({
-  expected: samplePrompt,
-  actual: samplePrompt,
-  startedAt,
-  completedAt,
-});
+try {
+  const options = parseCliArgs(process.argv.slice(2));
+  const output = await runApp({
+    mode: options.devMode ? "development" : "normal",
+    saveDirectory: options.saveDirectory,
+  });
 
-console.log("KeyQuest");
-console.log("A terminal typing adventure game for fun and effective practice.");
-console.log("");
-console.log(`Sample prompt: ${samplePrompt}`);
-console.log(`Baseline score model: ${score.wordsPerMinute.toFixed(1)} WPM, 100% accuracy`);
-console.log("");
-console.log("Next: build the interactive lesson loop from the tracked GitHub issues.");
+  console.log(output);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`KeyQuest failed: ${message}`);
+  process.exitCode = 1;
+}

--- a/src/save/codec.test.ts
+++ b/src/save/codec.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeDevelopmentSave,
+  decodeNormalSave,
+  encodeDevelopmentSave,
+  encodeNormalSave,
+} from "./codec.js";
+import { createNewSave } from "./model.js";
+
+describe("save codecs", () => {
+  const save = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+
+  it("round-trips normal saves without exposing plain JSON", () => {
+    const encoded = encodeNormalSave(save);
+
+    expect(encoded.startsWith("KQSV1.")).toBe(true);
+    expect(encoded).not.toContain("Apprentice");
+    expect(decodeNormalSave(encoded)).toEqual(save);
+  });
+
+  it("rejects tampered normal saves", () => {
+    const encoded = encodeNormalSave(save);
+    const tampered = encoded.replace("KQSV1.", "KQSV1.x");
+
+    expect(() => decodeNormalSave(tampered)).toThrow("integrity");
+  });
+
+  it("writes readable JSON in development mode", () => {
+    const encoded = encodeDevelopmentSave(save);
+
+    expect(encoded).toContain('"heroName": "Apprentice"');
+    expect(decodeDevelopmentSave(encoded)).toEqual(save);
+  });
+});

--- a/src/save/codec.ts
+++ b/src/save/codec.ts
@@ -1,0 +1,54 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import type { KeyQuestSave } from "./model.js";
+
+const NORMAL_SAVE_PREFIX = "KQSV1";
+const NORMAL_SAVE_SECRET = "keyquest-local-save-integrity-v1";
+
+export function encodeNormalSave(save: KeyQuestSave): string {
+  const canonical = JSON.stringify(save);
+  const payload = gzipSync(canonical).toString("base64url");
+  const signature = signPayload(payload);
+
+  return `${NORMAL_SAVE_PREFIX}.${payload}.${signature}`;
+}
+
+export function decodeNormalSave(content: string): KeyQuestSave {
+  const [prefix, payload, signature] = content.split(".");
+
+  if (prefix !== NORMAL_SAVE_PREFIX || payload === undefined || signature === undefined) {
+    throw new Error("Invalid KeyQuest save format");
+  }
+
+  const expectedSignature = signPayload(payload);
+  if (!safeEqual(signature, expectedSignature)) {
+    throw new Error("KeyQuest save integrity check failed");
+  }
+
+  const json = gunzipSync(Buffer.from(payload, "base64url")).toString("utf8");
+  return JSON.parse(json) as KeyQuestSave;
+}
+
+export function encodeDevelopmentSave(save: KeyQuestSave): string {
+  return `${JSON.stringify(save, null, 2)}\n`;
+}
+
+export function decodeDevelopmentSave(content: string): KeyQuestSave {
+  return JSON.parse(content) as KeyQuestSave;
+}
+
+function signPayload(payload: string): string {
+  return createHmac("sha256", NORMAL_SAVE_SECRET).update(payload).digest("base64url");
+}
+
+function safeEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+
+  if (actualBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -1,0 +1,111 @@
+export const SAVE_VERSION = 1;
+
+export type SaveMode = "normal" | "development";
+
+export type SkillTrackId =
+  | "homePosition"
+  | "fingerResponsibility"
+  | "homeRow"
+  | "accuracy"
+  | "rhythm";
+
+export type SkillTrack = {
+  readonly id: SkillTrackId;
+  readonly level: number;
+  readonly xp: number;
+};
+
+export type SessionRecord = {
+  readonly id: string;
+  readonly mode: SaveMode;
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly promptCount: number;
+  readonly accuracy: number;
+  readonly wordsPerMinute: number;
+  readonly xpGained: number;
+};
+
+export type KeyQuestSave = {
+  readonly version: typeof SAVE_VERSION;
+  readonly profile: {
+    readonly heroName: string;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+  };
+  readonly settings: {
+    readonly locale: string;
+    readonly colorMode: "auto" | "always" | "never";
+    readonly theme: "classic" | "forest" | "arcane" | "ember" | "mono";
+    readonly reducedMotion: boolean;
+  };
+  readonly journey: {
+    readonly day: number;
+    readonly chapter: number;
+    readonly storyFlag: "newGame" | "noviceHallStarted";
+  };
+  readonly progress: {
+    readonly totalXp: number;
+    readonly streakDays: number;
+    readonly sessions: readonly SessionRecord[];
+    readonly skills: readonly SkillTrack[];
+  };
+  readonly development: {
+    readonly everUsedDevMode: boolean;
+    readonly devSessions: number;
+  };
+};
+
+export function createNewSave(now: Date, mode: SaveMode): KeyQuestSave {
+  const timestamp = now.toISOString();
+
+  return {
+    version: SAVE_VERSION,
+    profile: {
+      heroName: "Apprentice",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    settings: {
+      locale: "en",
+      colorMode: "auto",
+      theme: "classic",
+      reducedMotion: false,
+    },
+    journey: {
+      day: 1,
+      chapter: 1,
+      storyFlag: "newGame",
+    },
+    progress: {
+      totalXp: 0,
+      streakDays: 0,
+      sessions: [],
+      skills: [
+        { id: "homePosition", level: 1, xp: 0 },
+        { id: "fingerResponsibility", level: 1, xp: 0 },
+        { id: "homeRow", level: 1, xp: 0 },
+        { id: "accuracy", level: 1, xp: 0 },
+        { id: "rhythm", level: 1, xp: 0 },
+      ],
+    },
+    development: {
+      everUsedDevMode: mode === "development",
+      devSessions: 0,
+    },
+  };
+}
+
+export function touchSave(save: KeyQuestSave, now: Date, mode: SaveMode): KeyQuestSave {
+  return {
+    ...save,
+    profile: {
+      ...save.profile,
+      updatedAt: now.toISOString(),
+    },
+    development: {
+      everUsedDevMode: save.development.everUsedDevMode || mode === "development",
+      devSessions: save.development.devSessions,
+    },
+  };
+}

--- a/src/save/store.test.ts
+++ b/src/save/store.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createSaveStore } from "./store.js";
+
+const tempDirectories: string[] = [];
+
+describe("createSaveStore", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+  });
+
+  it("creates tamper-friction normal saves", async () => {
+    const directory = await createTempDirectory();
+    const store = createSaveStore({ mode: "normal", directory });
+    const save = await store.loadOrCreate(new Date("2026-01-01T00:00:00.000Z"));
+
+    await store.write(save);
+
+    const content = await readFile(join(directory, "save.kq"), "utf8");
+    expect(content.startsWith("KQSV1.")).toBe(true);
+    expect(content).not.toContain("Apprentice");
+  });
+
+  it("creates readable development saves", async () => {
+    const directory = await createTempDirectory();
+    const store = createSaveStore({ mode: "development", directory });
+    const save = await store.loadOrCreate(new Date("2026-01-01T00:00:00.000Z"));
+
+    await store.write(save);
+
+    const content = await readFile(join(directory, "save.dev.json"), "utf8");
+    expect(content).toContain('"heroName": "Apprentice"');
+    expect(content).toContain('"everUsedDevMode": true');
+  });
+});
+
+async function createTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "keyquest-"));
+  tempDirectories.push(directory);
+  return directory;
+}

--- a/src/save/store.ts
+++ b/src/save/store.ts
@@ -1,0 +1,69 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  decodeDevelopmentSave,
+  decodeNormalSave,
+  encodeDevelopmentSave,
+  encodeNormalSave,
+} from "./codec.js";
+import { createNewSave, touchSave, type KeyQuestSave, type SaveMode } from "./model.js";
+
+export type SaveStore = {
+  readonly mode: SaveMode;
+  readonly filePath: string;
+  readonly loadOrCreate: (now: Date) => Promise<KeyQuestSave>;
+  readonly write: (save: KeyQuestSave) => Promise<void>;
+};
+
+export function createSaveStore(options: {
+  readonly mode: SaveMode;
+  readonly directory?: string;
+}): SaveStore {
+  const directory = options.directory ?? defaultSaveDirectory();
+  const fileName = options.mode === "development" ? "save.dev.json" : "save.kq";
+  const filePath = join(directory, fileName);
+
+  return {
+    mode: options.mode,
+    filePath,
+    async loadOrCreate(now: Date): Promise<KeyQuestSave> {
+      try {
+        const content = await readFile(filePath, "utf8");
+        const loaded =
+          options.mode === "development"
+            ? decodeDevelopmentSave(content)
+            : decodeNormalSave(content.trim());
+
+        return touchSave(loaded, now, options.mode);
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return createNewSave(now, options.mode);
+        }
+
+        throw error;
+      }
+    },
+    async write(save: KeyQuestSave): Promise<void> {
+      await mkdir(directory, { recursive: true });
+      const content =
+        options.mode === "development" ? encodeDevelopmentSave(save) : encodeNormalSave(save);
+
+      await writeFile(filePath, content, "utf8");
+    },
+  };
+}
+
+export function defaultSaveDirectory(): string {
+  return join(homedir(), ".keyquest");
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { readonly code?: string }).code === "ENOENT"
+  );
+}

--- a/src/scenes/manager.test.ts
+++ b/src/scenes/manager.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { scoreTypingResult } from "../core/scoring.js";
+import { createNewSave } from "../save/model.js";
+import { formatSceneSequence, renderSceneSequence } from "./manager.js";
+import { defaultScenes } from "./scenes.js";
+
+describe("scene manager", () => {
+  it("renders the initial scene sequence", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const prompt = "fj jf";
+    const outputs = renderSceneSequence({
+      scenes: defaultScenes,
+      context: {
+        save: createNewSave(now, "normal"),
+        mode: "normal",
+        now,
+        practicePreview: {
+          prompt,
+          score: scoreTypingResult({
+            expected: prompt,
+            actual: prompt,
+            startedAt: now,
+            completedAt: new Date(now.getTime() + 5_000),
+          }),
+        },
+      },
+    });
+
+    expect(outputs.map((output) => output.id)).toEqual([
+      "title",
+      "story",
+      "status",
+      "practicePreview",
+    ]);
+    expect(formatSceneSequence(outputs)).toContain("Novice Hall");
+  });
+});

--- a/src/scenes/manager.ts
+++ b/src/scenes/manager.ts
@@ -1,0 +1,28 @@
+import type { Scene, SceneContext, SceneId, SceneOutput } from "./types.js";
+
+export function renderSceneSequence(options: {
+  readonly scenes: readonly Scene[];
+  readonly context: SceneContext;
+  readonly startAt?: SceneId;
+}): readonly SceneOutput[] {
+  const scenesById = new Map(options.scenes.map((scene) => [scene.id, scene]));
+  const outputs: SceneOutput[] = [];
+  let current: SceneId = options.startAt ?? "title";
+
+  while (current !== "exit") {
+    const scene = scenesById.get(current);
+    if (scene === undefined) {
+      throw new Error(`Unknown scene: ${current}`);
+    }
+
+    const output = scene.render(options.context);
+    outputs.push(output);
+    current = output.next;
+  }
+
+  return outputs;
+}
+
+export function formatSceneSequence(outputs: readonly SceneOutput[]): string {
+  return outputs.map((output) => output.lines.join("\n")).join("\n\n");
+}

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,0 +1,79 @@
+import type { Scene, SceneContext, SceneOutput } from "./types.js";
+
+export const titleScene: Scene = {
+  id: "title",
+  render(context: SceneContext): SceneOutput {
+    return {
+      id: "title",
+      lines: [
+        "KeyQuest",
+        "A terminal typing adventure for steady hands.",
+        context.mode === "development" ? "DEV MODE - debug magic is not sung by bards." : "",
+      ].filter((line) => line.length > 0),
+      next: "story",
+    };
+  },
+};
+
+export const storyScene: Scene = {
+  id: "story",
+  render(context: SceneContext): SceneOutput {
+    return {
+      id: "story",
+      lines: [
+        "Story",
+        `Day ${context.save.journey.day}: Novice Hall`,
+        "The old instructor points to the home row.",
+        '"Before the blade, learn the stance."',
+      ],
+      next: "status",
+    };
+  },
+};
+
+export const statusScene: Scene = {
+  id: "status",
+  render(context: SceneContext): SceneOutput {
+    const skills = context.save.progress.skills
+      .slice(0, 3)
+      .map((skill) => `${skill.id} Lv.${skill.level}`)
+      .join(" / ");
+
+    return {
+      id: "status",
+      lines: [
+        "Status",
+        `Hero: ${context.save.profile.heroName}`,
+        `XP: ${context.save.progress.totalXp}`,
+        `Streak: ${context.save.progress.streakDays} days`,
+        `Training: ${skills}`,
+      ],
+      next: "practicePreview",
+    };
+  },
+};
+
+export const practicePreviewScene: Scene = {
+  id: "practicePreview",
+  render(context: SceneContext): SceneOutput {
+    const { prompt, score } = context.practicePreview;
+
+    return {
+      id: "practicePreview",
+      lines: [
+        "Practice Preview",
+        `Prompt: ${prompt}`,
+        `Baseline: ${score.wordsPerMinute.toFixed(1)} WPM / ${Math.round(score.accuracy * 100)}% accuracy`,
+        "Next implementation: replace this preview with the interactive typing loop.",
+      ],
+      next: "exit",
+    };
+  },
+};
+
+export const defaultScenes: readonly Scene[] = [
+  titleScene,
+  storyScene,
+  statusScene,
+  practicePreviewScene,
+];

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -1,0 +1,25 @@
+import type { Score } from "../core/scoring.js";
+import type { KeyQuestSave, SaveMode } from "../save/model.js";
+
+export type SceneId = "title" | "story" | "status" | "practicePreview" | "exit";
+
+export type SceneContext = {
+  readonly save: KeyQuestSave;
+  readonly mode: SaveMode;
+  readonly now: Date;
+  readonly practicePreview: {
+    readonly prompt: string;
+    readonly score: Score;
+  };
+};
+
+export type SceneOutput = {
+  readonly id: SceneId;
+  readonly lines: readonly string[];
+  readonly next: SceneId;
+};
+
+export type Scene = {
+  readonly id: SceneId;
+  readonly render: (context: SceneContext) => SceneOutput;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- Add CLI parsing for `--dev`, `-dev`, and `--save-dir`.
- Add normal and development save stores, with tamper-friction normal saves and readable dev JSON saves.
- Add a thin scene shell for title, story, status, and practice preview screens.

## Linked Issue
Closes #17
Refs #7
Refs #2

## Test plan
- [x] npm run verify
- [x] npm run dev -- --save-dir /tmp/keyquest-smoke-normal
- [x] npm run dev -- --dev --save-dir /tmp/keyquest-smoke-dev


Made with [Cursor](https://cursor.com)