### PR TITLE
Harden testing strategy

### DIFF
--- a/.cursor/rules/typescript-cli.mdc
+++ b/.cursor/rules/typescript-cli.mdc
@@ -15,4 +15,6 @@ alwaysApply: false
 - Use type-only imports when importing only types and keep `.js` extensions in local imports.
 - Wrap raw-mode input, ANSI output, filesystem access, clocks, and process args behind small modules.
 - Follow `docs/UI_SPEC.md`; keep typing screens stable and avoid continuous animation while typing.
-- Add focused Vitest coverage beside modules, especially for parsing, save codecs, scenes, scoring, and progression.
+- Follow `docs/TESTING_STRATEGY.md`; add focused Vitest coverage beside modules.
+- Test parsing, save codecs/stores, scenes, scoring, progression, achievements, and terminal fallbacks as contracts.
+- Use fixed dates, temporary directories, and injected dependencies; avoid sleeps, broad snapshots, and real randomness.

--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ This project is managed with GitHub Issues and local Markdown planning docs.
 - Achievements: `docs/ACHIEVEMENTS.md`
 - Localization: `docs/LOCALIZATION.md`
 - Save data: `docs/SAVE_DATA.md`
+- Testing strategy: `docs/TESTING_STRATEGY.md`
 - Development philosophy and policy: `docs/DEVELOPMENT.md`
 - Coding standards: `docs/CODING_STANDARDS.md`

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -77,15 +77,16 @@
 
 ## Tests
 
-- Unit test scoring, parsing, validation, and progression rules.
+- Follow `docs/TESTING_STRATEGY.md`.
 - Add tests next to the module under test with `*.test.ts`.
-- Test public behavior, not private implementation details.
+- Test public behavior and contracts, not private implementation details.
 - Use deterministic dates, temporary directories, and injected dependencies.
 - For save and CLI code, test both normal and development modes.
-- Add regression tests when fixing bugs.
-- Add integration or smoke tests for CLI behavior once the loop stabilizes.
-- Do not over-test throwaway prototypes; convert useful prototypes into tested
-  modules before they become foundation code.
+- Add regression tests when fixing bugs unless the test would be more brittle
+  than useful.
+- Do not use broad snapshots for ANSI-heavy output, animation frames, or save
+  files with timestamps.
+- Run `npm run verify` before pushing.
 
 ## Formatting
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,0 +1,144 @@
+# Testing Strategy
+
+## Goals
+
+Tests should make KeyQuest safe to change quickly. The project should favor
+small, deterministic tests around behavior and contracts over broad snapshots or
+fragile terminal recordings.
+
+Every meaningful change should answer: what behavior could break, and where is
+that protected?
+
+## Test Layers
+
+### Unit Tests
+
+Use unit tests for pure or nearly pure modules:
+
+- scoring
+- lesson parsing and validation
+- progression rules
+- achievement triggers
+- scene transitions
+- theme and color-mode resolution
+- save encoding and migration transforms
+
+Unit tests should be fast, deterministic, and colocated next to the module under
+test as `*.test.ts`.
+
+### Boundary Tests
+
+Use boundary tests where KeyQuest touches the outside world:
+
+- CLI argument parsing
+- save store filesystem behavior
+- normal vs development save modes
+- corrupted or tampered saves
+- locale catalog validation
+- terminal capability detection
+
+Boundary tests may use temporary directories and injected dependencies. They must
+clean up after themselves.
+
+### Integration Tests
+
+Use integration tests for multi-module behavior that represents a real user
+path:
+
+- app startup
+- title to story to status to practice scene flow
+- a practice session producing a result
+- save-load-resume behavior
+- locale selection and fallback
+
+Integration tests should still avoid real user input until the interactive
+terminal layer stabilizes.
+
+### Smoke Tests
+
+Smoke tests are lightweight command-level checks. They should prove the package
+starts and key modes do not crash.
+
+Current manual smoke checks:
+
+```bash
+npm run dev -- --save-dir /tmp/keyquest-smoke-normal
+npm run dev -- --dev --save-dir /tmp/keyquest-smoke-dev
+```
+
+Automate smoke tests once the CLI output stabilizes enough to avoid noisy churn.
+
+### Regression Tests
+
+Every bug fix should add a regression test unless the bug is purely cosmetic or
+the test would be more brittle than useful. The regression test should fail
+without the fix.
+
+## Required Tests by Change Type
+
+- Scoring, progression, achievements: unit tests for normal, edge, and failure
+  cases.
+- Save data: round-trip tests, tamper/corruption tests, migration tests, and
+  normal/development mode tests.
+- CLI options: parsing tests for valid aliases, invalid options, and defaults.
+- Scenes: transition order and user-visible essential text.
+- Terminal UI: semantic output, no-color behavior, reduced-motion behavior, and
+  size handling.
+- Localization: required key coverage and fallback behavior.
+- Lessons: schema validation and representative valid/invalid fixtures.
+
+Documentation-only changes do not need new tests, but `npm run verify` should
+still pass.
+
+## Determinism Rules
+
+- Use fixed `Date` values or injected clocks.
+- Use temporary directories for filesystem tests.
+- Avoid shared mutable module state.
+- Avoid real randomness in tests. Inject deterministic values.
+- Do not depend on the user's home directory, locale, terminal size, or color
+  support unless explicitly testing detection logic.
+- Do not sleep in tests. Use fake timers or pure functions.
+
+## Snapshot Policy
+
+Snapshots are allowed only for stable, user-facing text where a snapshot improves
+reviewability. Prefer direct assertions for important fields and messages.
+
+Do not snapshot:
+
+- ANSI escape-heavy output
+- animation frames
+- full save files with timestamps
+- large scene output when a few assertions would be clearer
+
+## Interactive Terminal Policy
+
+Interactive raw-mode input should be wrapped behind small modules. Test the
+state machine and rendering helpers directly before testing real terminal input.
+
+When browser-like or pseudo-terminal automation is introduced, keep those tests
+small and separate from fast unit tests.
+
+## Coverage Expectations
+
+Do not chase percentage coverage blindly. KeyQuest should instead keep strong
+coverage on high-risk contracts:
+
+- save compatibility and integrity
+- scoring and progression math
+- lesson validation
+- achievement triggers
+- CLI option behavior
+- terminal fallback behavior
+
+Coverage tooling can be added after the first playable loop, when the code shape
+is stable enough for the metric to be useful.
+
+## Test Commands
+
+- `npm test`: run the full test suite once.
+- `npm run test:watch`: run tests in watch mode while developing.
+- `npm run verify`: typecheck, lint, format-check, and tests.
+
+Run `npm run verify` before pushing or opening a PR.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
+    "test:watch": "vitest",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run test"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Add a dedicated testing strategy covering unit, boundary, integration, smoke, regression, and future terminal tests.
- Tighten coding standards and Cursor TypeScript rule to point future work at the testing policy.
- Add `npm run test:watch` for development-time feedback.

## Linked Issue
Closes #21

## Test plan
- [x] npm run verify


Made with [Cursor](https://cursor.com)