### PR TITLE
Add first playable typing loop

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,12 +2,9 @@
 
 ## Now
 
-- [ ] Complete [#17](https://github.com/hideyukiMORI/keyquest/issues/17): scene shell and save foundation.
-- [ ] Build [#2](https://github.com/hideyukiMORI/keyquest/issues/2): first interactive typing loop.
 - [ ] Define [#7](https://github.com/hideyukiMORI/keyquest/issues/7): local save-file shape for session history, XP, streaks, and settings.
 - [ ] Design [#11](https://github.com/hideyukiMORI/keyquest/issues/11): first home-position and finger-usage lesson sequence.
-- [ ] Design [#15](https://github.com/hideyukiMORI/keyquest/issues/15): minimal modern CLI motion and feedback.
-- [ ] Add the first 10-minute daily session result screen.
+- [ ] Extend the first playable loop into a timed 10-minute daily session.
 - [ ] Keep `main` green with `npm run verify`.
 
 ## Next

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { runApp } from "./app.js";
+import type { TextInput } from "./cli/text-input.js";
 
 const tempDirectories: string[] = [];
 
@@ -17,23 +18,30 @@ describe("runApp", () => {
     const output = await runApp({
       mode: "normal",
       saveDirectory: await createTempDirectory(),
+      textInput: createFixedTextInput("f j f j asdf jkl;"),
       now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
     expect(output).toContain("KeyQuest");
     expect(output).toContain("Story");
     expect(output).toContain("Status");
-    expect(output).toContain("Practice Preview");
+    expect(output).toContain("Practice");
+    expect(output).toContain("Result");
+    expect(output).toContain("XP gained");
   });
 
   it("marks development mode visibly", async () => {
     const output = await runApp({
       mode: "development",
       saveDirectory: await createTempDirectory(),
+      textInput: createFixedTextInput("f j f j asdf jkl;"),
       now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
     expect(output).toContain("DEV MODE");
+    expect(output).toContain("DEV MODE CLEAR");
   });
 });
 
@@ -41,4 +49,13 @@ async function createTempDirectory(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), "keyquest-app-"));
   tempDirectories.push(directory);
   return directory;
+}
+
+function createFixedTextInput(input: string): TextInput {
+  return {
+    readLine(): Promise<string> {
+      return Promise.resolve(input);
+    },
+    close(): void {},
+  };
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,22 @@
-import { scoreTypingResult } from "./core/scoring.js";
+import type { TextInput } from "./cli/text-input.js";
+import { completePracticeSession, type PracticePrompt } from "./practice/session.js";
 import type { SaveMode } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
-import { defaultScenes } from "./scenes/scenes.js";
+import { defaultScenes, renderPracticeResult } from "./scenes/scenes.js";
 
 export type RunAppOptions = {
   readonly mode: SaveMode;
   readonly saveDirectory: string | undefined;
+  readonly textInput: TextInput;
   readonly now?: Date;
+  readonly completedAt?: Date;
+};
+
+const FIRST_PRACTICE_PROMPT: PracticePrompt = {
+  id: "novice-hall-home-position-1",
+  text: "f j f j asdf jkl;",
+  skillIds: ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
 };
 
 export async function runApp(options: RunAppOptions): Promise<string> {
@@ -17,15 +26,6 @@ export async function runApp(options: RunAppOptions): Promise<string> {
     ...(options.saveDirectory === undefined ? {} : { directory: options.saveDirectory }),
   });
   const save = await saveStore.loadOrCreate(now);
-  await saveStore.write(save);
-
-  const samplePrompt = "f j f j asdf jkl;";
-  const previewScore = scoreTypingResult({
-    expected: samplePrompt,
-    actual: samplePrompt,
-    startedAt: now,
-    completedAt: new Date(now.getTime() + 20_000),
-  });
 
   const outputs = renderSceneSequence({
     scenes: defaultScenes,
@@ -33,12 +33,24 @@ export async function runApp(options: RunAppOptions): Promise<string> {
       save,
       mode: options.mode,
       now,
-      practicePreview: {
-        prompt: samplePrompt,
-        score: previewScore,
-      },
+      practicePrompt: FIRST_PRACTICE_PROMPT,
     },
   });
+  const introOutput = formatSceneSequence(outputs);
+  const actual = await options.textInput.readLine("> ");
+  const completedAt = options.completedAt ?? new Date();
+  const result = completePracticeSession({
+    save,
+    mode: options.mode,
+    prompt: FIRST_PRACTICE_PROMPT,
+    actual,
+    startedAt: now,
+    completedAt,
+  });
 
-  return formatSceneSequence(outputs);
+  await saveStore.write(result.updatedSave);
+
+  return [introOutput, renderPracticeResult({ ...result, mode: options.mode }).join("\n")].join(
+    "\n\n",
+  );
 }

--- a/src/cli/text-input.ts
+++ b/src/cli/text-input.ts
@@ -1,0 +1,26 @@
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+
+export type TextInput = {
+  readonly readLine: (prompt: string) => Promise<string>;
+  readonly close: () => void;
+};
+
+export function createNodeTextInput(options: {
+  readonly input: Readable;
+  readonly output: Writable;
+}): TextInput {
+  const readline = createInterface({
+    input: options.input,
+    output: options.output,
+  });
+
+  return {
+    readLine(prompt: string): Promise<string> {
+      return readline.question(prompt);
+    },
+    close(): void {
+      readline.close();
+    },
+  };
+}

--- a/src/core/scoring.test.ts
+++ b/src/core/scoring.test.ts
@@ -29,4 +29,16 @@ describe("scoreTypingResult", () => {
     expect(score.mistakes).toBe(3);
     expect(score.accuracy).toBe(0.4);
   });
+
+  it("uses a one second minimum elapsed time", () => {
+    const score = scoreTypingResult({
+      expected: "hello",
+      actual: "hello",
+      startedAt: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:00.010Z"),
+    });
+
+    expect(score.elapsedSeconds).toBe(1);
+    expect(score.wordsPerMinute).toBe(60);
+  });
 });

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -16,10 +16,11 @@ export type Score = {
 
 const WORD_LENGTH = 5;
 const SECONDS_PER_MINUTE = 60;
+const MINIMUM_ELAPSED_MILLISECONDS = 1000;
 
 export function scoreTypingResult(result: TypingResult): Score {
   const elapsedMilliseconds = Math.max(
-    1,
+    MINIMUM_ELAPSED_MILLISECONDS,
     result.completedAt.getTime() - result.startedAt.getTime(),
   );
   const elapsedSeconds = elapsedMilliseconds / 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,25 @@
 
 import { runApp } from "./app.js";
 import { parseCliArgs } from "./cli/args.js";
+import { createNodeTextInput } from "./cli/text-input.js";
 
 try {
   const options = parseCliArgs(process.argv.slice(2));
-  const output = await runApp({
-    mode: options.devMode ? "development" : "normal",
-    saveDirectory: options.saveDirectory,
+  const textInput = createNodeTextInput({
+    input: process.stdin,
+    output: process.stdout,
   });
+  try {
+    const output = await runApp({
+      mode: options.devMode ? "development" : "normal",
+      saveDirectory: options.saveDirectory,
+      textInput,
+    });
 
-  console.log(output);
+    console.log(output);
+  } finally {
+    textInput.close();
+  }
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`KeyQuest failed: ${message}`);

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { createNewSave } from "../save/model.js";
+import { calculatePracticeXp, completePracticeSession } from "./session.js";
+
+describe("completePracticeSession", () => {
+  it("scores input and appends a session record", () => {
+    const startedAt = new Date("2026-01-01T00:00:00.000Z");
+    const completedAt = new Date("2026-01-01T00:00:10.000Z");
+    const result = completePracticeSession({
+      save: createNewSave(startedAt, "normal"),
+      mode: "normal",
+      prompt: {
+        id: "home-row-1",
+        text: "f j f j",
+        skillIds: ["homePosition", "fingerResponsibility", "homeRow"],
+      },
+      actual: "f j f j",
+      startedAt,
+      completedAt,
+    });
+
+    expect(result.score.accuracy).toBe(1);
+    expect(result.xpGained).toBeGreaterThan(0);
+    expect(result.updatedSave.progress.sessions).toHaveLength(1);
+    expect(result.updatedSave.progress.totalXp).toBe(result.xpGained);
+    expect(result.updatedSave.journey.storyFlag).toBe("noviceHallStarted");
+  });
+
+  it("marks development sessions separately", () => {
+    const startedAt = new Date("2026-01-01T00:00:00.000Z");
+    const completedAt = new Date("2026-01-01T00:00:10.000Z");
+    const result = completePracticeSession({
+      save: createNewSave(startedAt, "development"),
+      mode: "development",
+      prompt: {
+        id: "home-row-1",
+        text: "f j f j",
+        skillIds: ["homePosition"],
+      },
+      actual: "f j f j",
+      startedAt,
+      completedAt,
+    });
+
+    expect(result.updatedSave.development.everUsedDevMode).toBe(true);
+    expect(result.updatedSave.development.devSessions).toBe(1);
+    expect(result.updatedSave.progress.sessions[0]?.mode).toBe("development");
+  });
+});
+
+describe("calculatePracticeXp", () => {
+  it("rewards perfect practice with a bonus", () => {
+    expect(
+      calculatePracticeXp({
+        totalCharacters: 5,
+        correctCharacters: 5,
+        mistakes: 0,
+        accuracy: 1,
+        wordsPerMinute: 10,
+        elapsedSeconds: 6,
+      }),
+    ).toBe(35);
+  });
+});

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -1,0 +1,133 @@
+import { scoreTypingResult, type Score } from "../core/scoring.js";
+import type { KeyQuestSave, SaveMode, SessionRecord, SkillTrack } from "../save/model.js";
+
+export type PracticePrompt = {
+  readonly id: string;
+  readonly text: string;
+  readonly skillIds: readonly SkillTrack["id"][];
+};
+
+export type PracticeSessionResult = {
+  readonly prompt: PracticePrompt;
+  readonly actual: string;
+  readonly score: Score;
+  readonly xpGained: number;
+  readonly updatedSave: KeyQuestSave;
+};
+
+export function completePracticeSession(options: {
+  readonly save: KeyQuestSave;
+  readonly mode: SaveMode;
+  readonly prompt: PracticePrompt;
+  readonly actual: string;
+  readonly startedAt: Date;
+  readonly completedAt: Date;
+}): PracticeSessionResult {
+  const score = scoreTypingResult({
+    expected: options.prompt.text,
+    actual: options.actual,
+    startedAt: options.startedAt,
+    completedAt: options.completedAt,
+  });
+  const xpGained = calculatePracticeXp(score);
+  const session: SessionRecord = {
+    id: createSessionId(options.completedAt),
+    mode: options.mode,
+    startedAt: options.startedAt.toISOString(),
+    completedAt: options.completedAt.toISOString(),
+    promptCount: 1,
+    accuracy: score.accuracy,
+    wordsPerMinute: score.wordsPerMinute,
+    xpGained,
+  };
+
+  return {
+    prompt: options.prompt,
+    actual: options.actual,
+    score,
+    xpGained,
+    updatedSave: applyPracticeResult({
+      save: options.save,
+      mode: options.mode,
+      session,
+      prompt: options.prompt,
+      completedAt: options.completedAt,
+    }),
+  };
+}
+
+export function calculatePracticeXp(score: Score): number {
+  const accuracyBonus = Math.round(score.accuracy * 20);
+  const characterXp = score.correctCharacters;
+  const perfectBonus = score.mistakes === 0 && score.totalCharacters > 0 ? 10 : 0;
+
+  return characterXp + accuracyBonus + perfectBonus;
+}
+
+function applyPracticeResult(options: {
+  readonly save: KeyQuestSave;
+  readonly mode: SaveMode;
+  readonly session: SessionRecord;
+  readonly prompt: PracticePrompt;
+  readonly completedAt: Date;
+}): KeyQuestSave {
+  return {
+    ...options.save,
+    profile: {
+      ...options.save.profile,
+      updatedAt: options.completedAt.toISOString(),
+    },
+    journey: {
+      ...options.save.journey,
+      storyFlag: "noviceHallStarted",
+    },
+    progress: {
+      ...options.save.progress,
+      totalXp: options.save.progress.totalXp + options.session.xpGained,
+      streakDays: Math.max(1, options.save.progress.streakDays),
+      sessions: [...options.save.progress.sessions, options.session],
+      skills: updateSkillTracks(
+        options.save.progress.skills,
+        options.prompt.skillIds,
+        options.session.xpGained,
+      ),
+    },
+    development: {
+      everUsedDevMode: options.save.development.everUsedDevMode || options.mode === "development",
+      devSessions:
+        options.mode === "development"
+          ? options.save.development.devSessions + 1
+          : options.save.development.devSessions,
+    },
+  };
+}
+
+function updateSkillTracks(
+  skills: readonly SkillTrack[],
+  trainedSkillIds: readonly SkillTrack["id"][],
+  xpGained: number,
+): readonly SkillTrack[] {
+  const skillXp = Math.max(1, Math.floor(xpGained / Math.max(1, trainedSkillIds.length)));
+
+  return skills.map((skill) => {
+    if (!trainedSkillIds.includes(skill.id)) {
+      return skill;
+    }
+
+    const nextXp = skill.xp + skillXp;
+
+    return {
+      ...skill,
+      xp: nextXp,
+      level: calculateLevel(nextXp),
+    };
+  });
+}
+
+function calculateLevel(xp: number): number {
+  return Math.floor(xp / 100) + 1;
+}
+
+function createSessionId(completedAt: Date): string {
+  return `session-${completedAt.toISOString()}`;
+}

--- a/src/scenes/manager.test.ts
+++ b/src/scenes/manager.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { scoreTypingResult } from "../core/scoring.js";
 import { createNewSave } from "../save/model.js";
 import { formatSceneSequence, renderSceneSequence } from "./manager.js";
 import { defaultScenes } from "./scenes.js";
@@ -15,14 +14,10 @@ describe("scene manager", () => {
         save: createNewSave(now, "normal"),
         mode: "normal",
         now,
-        practicePreview: {
-          prompt,
-          score: scoreTypingResult({
-            expected: prompt,
-            actual: prompt,
-            startedAt: now,
-            completedAt: new Date(now.getTime() + 5_000),
-          }),
+        practicePrompt: {
+          id: "home-row-1",
+          text: prompt,
+          skillIds: ["homePosition"],
         },
       },
     });
@@ -31,7 +26,7 @@ describe("scene manager", () => {
       "title",
       "story",
       "status",
-      "practicePreview",
+      "practiceIntro",
     ]);
     expect(formatSceneSequence(outputs)).toContain("Novice Hall");
   });

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,4 +1,4 @@
-import type { Scene, SceneContext, SceneOutput } from "./types.js";
+import type { PracticeResultView, Scene, SceneContext, SceneOutput } from "./types.js";
 
 export const titleScene: Scene = {
   id: "title",
@@ -48,23 +48,22 @@ export const statusScene: Scene = {
         `Streak: ${context.save.progress.streakDays} days`,
         `Training: ${skills}`,
       ],
-      next: "practicePreview",
+      next: "practiceIntro",
     };
   },
 };
 
-export const practicePreviewScene: Scene = {
-  id: "practicePreview",
+export const practiceIntroScene: Scene = {
+  id: "practiceIntro",
   render(context: SceneContext): SceneOutput {
-    const { prompt, score } = context.practicePreview;
+    const { practicePrompt } = context;
 
     return {
-      id: "practicePreview",
+      id: "practiceIntro",
       lines: [
-        "Practice Preview",
-        `Prompt: ${prompt}`,
-        `Baseline: ${score.wordsPerMinute.toFixed(1)} WPM / ${Math.round(score.accuracy * 100)}% accuracy`,
-        "Next implementation: replace this preview with the interactive typing loop.",
+        "Practice",
+        "Keep your fingers on the home position.",
+        `Type: ${practicePrompt.text}`,
       ],
       next: "exit",
     };
@@ -75,5 +74,24 @@ export const defaultScenes: readonly Scene[] = [
   titleScene,
   storyScene,
   statusScene,
-  practicePreviewScene,
+  practiceIntroScene,
 ];
+
+export function renderPracticeResult(result: PracticeResultView): readonly string[] {
+  const accuracy = Math.round(result.score.accuracy * 100);
+  const devLine =
+    result.mode === "development"
+      ? ["DEV MODE CLEAR - the bards refuse to sing about debug magic."]
+      : [];
+
+  return [
+    "Result",
+    `Expected: ${result.prompt.text}`,
+    `Typed:    ${result.actual}`,
+    `Accuracy: ${accuracy}%`,
+    `WPM: ${result.score.wordsPerMinute.toFixed(1)}`,
+    `Mistakes: ${result.score.mistakes}`,
+    `XP gained: ${result.xpGained}`,
+    ...devLine,
+  ];
+}

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -1,16 +1,14 @@
 import type { Score } from "../core/scoring.js";
+import type { PracticePrompt } from "../practice/session.js";
 import type { KeyQuestSave, SaveMode } from "../save/model.js";
 
-export type SceneId = "title" | "story" | "status" | "practicePreview" | "exit";
+export type SceneId = "title" | "story" | "status" | "practiceIntro" | "exit";
 
 export type SceneContext = {
   readonly save: KeyQuestSave;
   readonly mode: SaveMode;
   readonly now: Date;
-  readonly practicePreview: {
-    readonly prompt: string;
-    readonly score: Score;
-  };
+  readonly practicePrompt: PracticePrompt;
 };
 
 export type SceneOutput = {
@@ -22,4 +20,12 @@ export type SceneOutput = {
 export type Scene = {
   readonly id: SceneId;
   readonly render: (context: SceneContext) => SceneOutput;
+};
+
+export type PracticeResultView = {
+  readonly prompt: PracticePrompt;
+  readonly actual: string;
+  readonly score: Score;
+  readonly xpGained: number;
+  readonly mode: SaveMode;
 };


### PR DESCRIPTION
## Summary
- Replace the practice preview with a one-prompt typing loop backed by an injectable text input boundary.
- Add practice session scoring, XP calculation, save updates, and result rendering.
- Keep normal/dev mode behavior visible and covered by tests, including a WPM guard for near-instant input.

## Linked Issue
Closes #2
Refs #7

## Test plan
- [x] npm run verify
- [x] printf 'f j f j asdf jkl;\n' | npm run dev -- --save-dir /tmp/keyquest-first-loop-normal-2
- [x] printf 'f j f j asdf jkl;\n' | npm run dev -- --dev --save-dir /tmp/keyquest-first-loop-dev-2


Made with [Cursor](https://cursor.com)