### PR TITLE
Render scenes before input

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { runApp } from "./app.js";
 import type { TextInput } from "./cli/text-input.js";
+import type { TextOutput } from "./cli/text-output.js";
 import type { Lesson } from "./lessons/schema.js";
 
 const tempDirectories: string[] = [];
@@ -16,37 +17,63 @@ describe("runApp", () => {
   });
 
   it("renders the scene shell", async () => {
-    const output = await runApp({
+    const output = createMemoryOutput();
+    await runApp({
       mode: "normal",
       saveDirectory: await createTempDirectory(),
       textInput: createFixedTextInput("f j f j asdf jkl;"),
+      textOutput: output,
       lesson: createTestLesson(),
       lessonPath: undefined,
       now: new Date("2026-01-01T00:00:00.000Z"),
       completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
-    expect(output).toContain("KeyQuest");
-    expect(output).toContain("Story");
-    expect(output).toContain("Status");
-    expect(output).toContain("Practice");
-    expect(output).toContain("Result");
-    expect(output).toContain("XP gained");
+    expect(output.text()).toContain("KeyQuest");
+    expect(output.text()).toContain("Story");
+    expect(output.text()).toContain("Status");
+    expect(output.text()).toContain("Practice");
+    expect(output.text()).toContain("Result");
+    expect(output.text()).toContain("XP gained");
   });
 
   it("marks development mode visibly", async () => {
-    const output = await runApp({
+    const output = createMemoryOutput();
+    await runApp({
       mode: "development",
       saveDirectory: await createTempDirectory(),
       textInput: createFixedTextInput("f j f j asdf jkl;"),
+      textOutput: output,
       lesson: createTestLesson(),
       lessonPath: undefined,
       now: new Date("2026-01-01T00:00:00.000Z"),
       completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
-    expect(output).toContain("DEV MODE");
-    expect(output).toContain("DEV MODE CLEAR");
+    expect(output.text()).toContain("DEV MODE");
+    expect(output.text()).toContain("DEV MODE CLEAR");
+  });
+
+  it("renders practice instructions before waiting for input", async () => {
+    const output = createMemoryOutput();
+    const input = createAssertingTextInput(() => {
+      expect(output.text()).toContain("Type: f j f j asdf jkl;");
+      expect(output.text()).not.toContain("Result");
+      return "f j f j asdf jkl;";
+    });
+
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: input,
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Result");
   });
 });
 
@@ -82,5 +109,30 @@ function createFixedTextInput(input: string): TextInput {
       return Promise.resolve(input);
     },
     close(): void {},
+  };
+}
+
+function createAssertingTextInput(read: () => string): TextInput {
+  return {
+    readLine(): Promise<string> {
+      return Promise.resolve(read());
+    },
+    close(): void {},
+  };
+}
+
+function createMemoryOutput(): TextOutput & { readonly text: () => string } {
+  const chunks: string[] = [];
+
+  return {
+    write(text: string): void {
+      chunks.push(text);
+    },
+    writeLine(text: string): void {
+      chunks.push(`${text}\n`);
+    },
+    text(): string {
+      return chunks.join("");
+    },
   };
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import type { TextInput } from "./cli/text-input.js";
+import type { TextOutput } from "./cli/text-output.js";
 import { DEFAULT_LESSON_PATH, loadLessonFromFile, selectPracticePrompt } from "./lessons/loader.js";
 import type { Lesson } from "./lessons/schema.js";
 import { completePracticeSession } from "./practice/session.js";
@@ -11,13 +12,14 @@ export type RunAppOptions = {
   readonly mode: SaveMode;
   readonly saveDirectory: string | undefined;
   readonly textInput: TextInput;
+  readonly textOutput: TextOutput;
   readonly lesson: Lesson | undefined;
   readonly lessonPath: string | undefined;
   readonly now?: Date;
   readonly completedAt?: Date;
 };
 
-export async function runApp(options: RunAppOptions): Promise<string> {
+export async function runApp(options: RunAppOptions): Promise<void> {
   const now = options.now ?? new Date();
   const saveStore = createSaveStore({
     mode: options.mode,
@@ -39,6 +41,8 @@ export async function runApp(options: RunAppOptions): Promise<string> {
     },
   });
   const introOutput = formatSceneSequence(outputs);
+  options.textOutput.writeLine(introOutput);
+  options.textOutput.writeLine("");
   const actual = await options.textInput.readLine("> ");
   const completedAt = options.completedAt ?? new Date();
   const result = completePracticeSession({
@@ -52,7 +56,6 @@ export async function runApp(options: RunAppOptions): Promise<string> {
 
   await saveStore.write(result.updatedSave);
 
-  return [introOutput, renderPracticeResult({ ...result, mode: options.mode }).join("\n")].join(
-    "\n\n",
-  );
+  options.textOutput.writeLine("");
+  options.textOutput.writeLine(renderPracticeResult({ ...result, mode: options.mode }).join("\n"));
 }

--- a/src/cli/text-output.ts
+++ b/src/cli/text-output.ts
@@ -1,0 +1,17 @@
+import type { Writable } from "node:stream";
+
+export type TextOutput = {
+  readonly write: (text: string) => void;
+  readonly writeLine: (text: string) => void;
+};
+
+export function createNodeTextOutput(output: Writable): TextOutput {
+  return {
+    write(text: string): void {
+      output.write(text);
+    },
+    writeLine(text: string): void {
+      output.write(`${text}\n`);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { runApp } from "./app.js";
 import { parseCliArgs } from "./cli/args.js";
 import { createNodeTextInput } from "./cli/text-input.js";
+import { createNodeTextOutput } from "./cli/text-output.js";
 
 try {
   const options = parseCliArgs(process.argv.slice(2));
@@ -10,16 +11,16 @@ try {
     input: process.stdin,
     output: process.stdout,
   });
+  const textOutput = createNodeTextOutput(process.stdout);
   try {
-    const output = await runApp({
+    await runApp({
       mode: options.devMode ? "development" : "normal",
       saveDirectory: options.saveDirectory,
       lesson: undefined,
       lessonPath: options.lessonPath,
       textInput,
+      textOutput,
     });
-
-    console.log(output);
   } finally {
     textInput.close();
   }


### PR DESCRIPTION
## Summary
- Add a `TextOutput` boundary and stream scene text before requesting input.
- Keep result rendering after the typed answer is received.
- Add a test that asserts practice instructions are visible before input is read.

## Linked Issue
Closes #25

## Test plan
- [x] npm run verify
- [x] printf 'f j\n' | npm run dev -- --save-dir /tmp/keyquest-output-order


Made with [Cursor](https://cursor.com)