### PR TITLE
Add localized title and options flow

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -44,3 +44,14 @@ Suggested shape:
 
 The source locale should be English. Tests should verify that required keys exist
 for every supported locale before release.
+
+## Current Foundation
+
+- `src/i18n/messages.ts` owns supported locale IDs, display names, and the
+  message catalog.
+- Title and options UI use saved locale settings before the practice session
+  starts.
+- Language changes are persisted in the local save file.
+- English typing prompts stay in lesson files and are not localized.
+- `NEW GAME` and `LOAD GAME` are visible as planned title menu slots so the menu
+  can grow without changing the basic navigation shape.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -21,7 +21,7 @@ describe("runApp", () => {
     await runApp({
       mode: "normal",
       saveDirectory: await createTempDirectory(),
-      textInput: createFixedTextInput("f j f j asdf jkl;"),
+      textInput: createQueuedTextInput(["1", "f j f j asdf jkl;"]),
       textOutput: output,
       lesson: createTestLesson(),
       lessonPath: undefined,
@@ -42,7 +42,7 @@ describe("runApp", () => {
     await runApp({
       mode: "development",
       saveDirectory: await createTempDirectory(),
-      textInput: createFixedTextInput("f j f j asdf jkl;"),
+      textInput: createQueuedTextInput(["1", "f j f j asdf jkl;"]),
       textOutput: output,
       lesson: createTestLesson(),
       lessonPath: undefined,
@@ -56,7 +56,14 @@ describe("runApp", () => {
 
   it("renders practice instructions before waiting for input", async () => {
     const output = createMemoryOutput();
+    let readCount = 0;
     const input = createAssertingTextInput(() => {
+      readCount += 1;
+      if (readCount === 1) {
+        expect(output.text()).toContain("Title");
+        return "1";
+      }
+
       expect(output.text()).toContain("Type: f j f j asdf jkl;");
       expect(output.text()).not.toContain("Result");
       return "f j f j asdf jkl;";
@@ -74,6 +81,25 @@ describe("runApp", () => {
     });
 
     expect(output.text()).toContain("Result");
+  });
+
+  it("lets the player change language before starting", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["2", "2", "1", "f j f j asdf jkl;"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("言語を 日本語 に設定しました。");
+    expect(output.text()).toContain("タイトル");
+    expect(output.text()).toContain("ストーリー");
+    expect(output.text()).toContain("結果");
   });
 });
 
@@ -103,9 +129,16 @@ function createTestLesson(): Lesson {
   };
 }
 
-function createFixedTextInput(input: string): TextInput {
+function createQueuedTextInput(inputs: readonly string[]): TextInput {
+  const queue = [...inputs];
+
   return {
     readLine(): Promise<string> {
+      const input = queue.shift();
+      if (input === undefined) {
+        return Promise.reject(new Error("No queued test input"));
+      }
+
       return Promise.resolve(input);
     },
     close(): void {},

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,17 @@
 import type { TextInput } from "./cli/text-input.js";
 import type { TextOutput } from "./cli/text-output.js";
+import { createTranslator, localeDisplayName } from "./i18n/messages.js";
 import { DEFAULT_LESSON_PATH, loadLessonFromFile, selectPracticePrompt } from "./lessons/loader.js";
 import type { Lesson } from "./lessons/schema.js";
+import {
+  createMenuTranslator,
+  parseLocaleChoice,
+  parseTitleMenuAction,
+  renderLanguageOptions,
+  renderTitleMenu,
+} from "./menu/title-menu.js";
 import { completePracticeSession } from "./practice/session.js";
-import type { SaveMode } from "./save/model.js";
+import { updateLocale, type KeyQuestSave, type SaveMode } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
 import { defaultScenes, renderPracticeResult } from "./scenes/scenes.js";
@@ -26,16 +34,27 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     ...(options.saveDirectory === undefined ? {} : { directory: options.saveDirectory }),
   });
   const save = await saveStore.loadOrCreate(now);
+  const menuSave = await runTitleMenu({
+    save,
+    mode: options.mode,
+    now,
+    textInput: options.textInput,
+    textOutput: options.textOutput,
+    writeSave: saveStore.write,
+  });
   const lesson =
     options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? DEFAULT_LESSON_PATH));
   const practicePrompt = selectPracticePrompt(lesson);
+  const translator = createTranslator(menuSave.settings.locale);
 
   const outputs = renderSceneSequence({
     scenes: defaultScenes,
+    startAt: "story",
     context: {
-      save,
+      save: menuSave,
       mode: options.mode,
       now,
+      translator,
       lesson,
       practicePrompt,
     },
@@ -46,7 +65,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   const actual = await options.textInput.readLine("> ");
   const completedAt = options.completedAt ?? new Date();
   const result = completePracticeSession({
-    save,
+    save: menuSave,
     mode: options.mode,
     prompt: practicePrompt,
     actual,
@@ -57,5 +76,65 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   await saveStore.write(result.updatedSave);
 
   options.textOutput.writeLine("");
-  options.textOutput.writeLine(renderPracticeResult({ ...result, mode: options.mode }).join("\n"));
+  options.textOutput.writeLine(
+    renderPracticeResult({ ...result, mode: options.mode }, translator).join("\n"),
+  );
+}
+
+async function runTitleMenu(options: {
+  readonly save: KeyQuestSave;
+  readonly mode: SaveMode;
+  readonly now: Date;
+  readonly textInput: TextInput;
+  readonly textOutput: TextOutput;
+  readonly writeSave: (save: KeyQuestSave) => Promise<void>;
+}): Promise<KeyQuestSave> {
+  let save = options.save;
+
+  for (;;) {
+    const translator = createMenuTranslator(save);
+    options.textOutput.writeLine(renderTitleMenu(save, translator).join("\n"));
+    if (options.mode === "development") {
+      options.textOutput.writeLine(translator.t("dev.banner"));
+    }
+
+    const action = parseTitleMenuAction(
+      await options.textInput.readLine(translator.t("title.menu.prompt")),
+    );
+    if (action === "start") {
+      options.textOutput.writeLine("");
+      return save;
+    }
+
+    const selectedLocale = await runLanguageOptions({
+      save,
+      textInput: options.textInput,
+      textOutput: options.textOutput,
+    });
+    save = updateLocale(save, selectedLocale, options.now);
+    await options.writeSave(save);
+  }
+}
+
+async function runLanguageOptions(options: {
+  readonly save: KeyQuestSave;
+  readonly textInput: TextInput;
+  readonly textOutput: TextOutput;
+}): Promise<KeyQuestSave["settings"]["locale"]> {
+  const translator = createMenuTranslator(options.save);
+  options.textOutput.writeLine("");
+  options.textOutput.writeLine(
+    renderLanguageOptions(options.save.settings.locale, translator).join("\n"),
+  );
+  const selectedLocale = parseLocaleChoice(
+    await options.textInput.readLine(translator.t("options.prompt")),
+    options.save.settings.locale,
+  );
+  const nextTranslator = createTranslator(selectedLocale);
+  options.textOutput.writeLine(
+    nextTranslator.t("options.saved", { language: localeDisplayName(selectedLocale) }),
+  );
+  options.textOutput.writeLine("");
+
+  return selectedLocale;
 }

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCompleteCatalogs,
+  createTranslator,
+  localeDisplayName,
+  resolveLocale,
+} from "./messages.js";
+
+describe("i18n messages", () => {
+  it("keeps every locale catalog complete", () => {
+    expect(() => {
+      assertCompleteCatalogs();
+    }).not.toThrow();
+  });
+
+  it("resolves unsupported locales to English", () => {
+    expect(resolveLocale("unknown")).toBe("en");
+  });
+
+  it("interpolates localized messages", () => {
+    const translator = createTranslator("ja");
+
+    expect(translator.t("options.saved", { language: localeDisplayName("ja") })).toBe(
+      "言語を 日本語 に設定しました。",
+    );
+  });
+});

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,0 +1,195 @@
+export const SUPPORTED_LOCALES = ["en", "ja", "zh-CN", "ko", "es", "pt-BR"] as const;
+
+export type LocaleId = (typeof SUPPORTED_LOCALES)[number];
+
+export type MessageKey = keyof typeof EN_MESSAGES;
+
+export type Translator = {
+  readonly locale: LocaleId;
+  readonly t: (key: MessageKey, params?: Readonly<Record<string, string | number>>) => string;
+};
+
+const EN_MESSAGES = {
+  "app.title": "KeyQuest",
+  "app.subtitle": "A terminal typing adventure for steady hands.",
+  "dev.banner": "DEV MODE - debug magic is not sung by bards.",
+  "title.menu.heading": "Title",
+  "title.menu.continue": "Continue",
+  "title.menu.newGame": "New Game",
+  "title.menu.loadGame": "Load Game",
+  "title.menu.options": "Options",
+  "title.menu.start": "Start",
+  "title.menu.prompt": "Choose: ",
+  "title.menu.planned": "planned",
+  "options.heading": "Options",
+  "options.language": "Language",
+  "options.back": "Back",
+  "options.prompt": "Choose language: ",
+  "options.saved": "Language set to {language}.",
+  "story.heading": "Story",
+  "story.noviceIntro": "The old instructor points to the home row.",
+  "story.noviceQuote": '"Before the blade, learn the stance."',
+  "status.heading": "Status",
+  "status.hero": "Hero: {hero}",
+  "status.xp": "XP: {xp}",
+  "status.streak": "Streak: {days} days",
+  "status.training": "Training: {skills}",
+  "practice.heading": "Practice",
+  "practice.lesson": "Lesson: {lesson}",
+  "practice.homeHint": "Keep your fingers on the home position.",
+  "practice.keys": "Keys: {keys}",
+  "practice.fingers": "Fingers: {fingers}",
+  "practice.type": "Type: {text}",
+  "result.heading": "Result",
+  "result.expected": "Expected: {text}",
+  "result.typed": "Typed:    {text}",
+  "result.accuracy": "Accuracy: {accuracy}%",
+  "result.wpm": "WPM: {wpm}",
+  "result.mistakes": "Mistakes: {mistakes}",
+  "result.xpGained": "XP gained: {xp}",
+  "result.devClear": "DEV MODE CLEAR - the bards refuse to sing about debug magic.",
+} as const;
+
+const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
+  en: EN_MESSAGES,
+  ja: {
+    ...EN_MESSAGES,
+    "app.subtitle": "落ち着いた指づかいのためのターミナルタイピング冒険。",
+    "dev.banner": "DEV MODE - デバッグ魔法の功績は吟遊詩人が歌ってくれません。",
+    "title.menu.heading": "タイトル",
+    "title.menu.continue": "つづきから",
+    "title.menu.newGame": "ニューゲーム",
+    "title.menu.loadGame": "ロードゲーム",
+    "title.menu.options": "オプション",
+    "title.menu.start": "スタート",
+    "title.menu.prompt": "選択: ",
+    "title.menu.planned": "予定",
+    "options.heading": "オプション",
+    "options.language": "言語",
+    "options.back": "戻る",
+    "options.prompt": "言語を選択: ",
+    "options.saved": "言語を {language} に設定しました。",
+    "story.heading": "ストーリー",
+    "story.noviceIntro": "老教官はホームポジションを指さした。",
+    "story.noviceQuote": "「剣の前に、まず構えを覚えよ。」",
+    "status.heading": "ステータス",
+    "status.hero": "勇者: {hero}",
+    "status.xp": "XP: {xp}",
+    "status.streak": "継続: {days}日",
+    "status.training": "訓練: {skills}",
+    "practice.heading": "練習",
+    "practice.lesson": "レッスン: {lesson}",
+    "practice.homeHint": "指をホームポジションに置いたままにしましょう。",
+    "practice.keys": "キー: {keys}",
+    "practice.fingers": "指: {fingers}",
+    "practice.type": "入力: {text}",
+    "result.heading": "結果",
+    "result.expected": "お題: {text}",
+    "result.typed": "入力: {text}",
+    "result.accuracy": "正確性: {accuracy}%",
+    "result.wpm": "WPM: {wpm}",
+    "result.mistakes": "ミス: {mistakes}",
+    "result.xpGained": "獲得XP: {xp}",
+    "result.devClear": "DEV MODE CLEAR - デバッグ魔法なので少しだけ残念なクリアです。",
+  },
+  "zh-CN": {
+    ...EN_MESSAGES,
+    "title.menu.heading": "标题",
+    "title.menu.options": "选项",
+    "title.menu.start": "开始",
+    "options.heading": "选项",
+    "options.language": "语言",
+    "options.back": "返回",
+    "story.heading": "故事",
+    "status.heading": "状态",
+    "practice.heading": "练习",
+    "result.heading": "结果",
+  },
+  ko: {
+    ...EN_MESSAGES,
+    "title.menu.heading": "타이틀",
+    "title.menu.options": "옵션",
+    "title.menu.start": "시작",
+    "options.heading": "옵션",
+    "options.language": "언어",
+    "options.back": "뒤로",
+    "story.heading": "스토리",
+    "status.heading": "상태",
+    "practice.heading": "연습",
+    "result.heading": "결과",
+  },
+  es: {
+    ...EN_MESSAGES,
+    "title.menu.heading": "Título",
+    "title.menu.options": "Opciones",
+    "title.menu.start": "Empezar",
+    "options.heading": "Opciones",
+    "options.language": "Idioma",
+    "options.back": "Volver",
+    "story.heading": "Historia",
+    "status.heading": "Estado",
+    "practice.heading": "Práctica",
+    "result.heading": "Resultado",
+  },
+  "pt-BR": {
+    ...EN_MESSAGES,
+    "title.menu.heading": "Título",
+    "title.menu.options": "Opções",
+    "title.menu.start": "Começar",
+    "options.heading": "Opções",
+    "options.language": "Idioma",
+    "options.back": "Voltar",
+    "story.heading": "História",
+    "status.heading": "Status",
+    "practice.heading": "Prática",
+    "result.heading": "Resultado",
+  },
+};
+
+export function createTranslator(locale: string): Translator {
+  const resolvedLocale = resolveLocale(locale);
+  const catalog = CATALOGS[resolvedLocale];
+
+  return {
+    locale: resolvedLocale,
+    t(key: MessageKey, params: Readonly<Record<string, string | number>> = {}): string {
+      return interpolate(catalog[key] ?? EN_MESSAGES[key], params);
+    },
+  };
+}
+
+export function resolveLocale(locale: string): LocaleId {
+  return SUPPORTED_LOCALES.includes(locale as LocaleId) ? (locale as LocaleId) : "en";
+}
+
+export function localeDisplayName(locale: LocaleId): string {
+  const names: Readonly<Record<LocaleId, string>> = {
+    en: "English",
+    ja: "日本語",
+    "zh-CN": "简体中文",
+    ko: "한국어",
+    es: "Español",
+    "pt-BR": "Português (Brasil)",
+  };
+
+  return names[locale];
+}
+
+export function assertCompleteCatalogs(): void {
+  const keys = Object.keys(EN_MESSAGES) as MessageKey[];
+
+  for (const locale of SUPPORTED_LOCALES) {
+    for (const key of keys) {
+      if (CATALOGS[locale][key] === undefined) {
+        throw new Error(`Missing message key ${key} for locale ${locale}`);
+      }
+    }
+  }
+}
+
+function interpolate(message: string, params: Readonly<Record<string, string | number>>): string {
+  return message.replaceAll(/\{([a-zA-Z0-9]+)\}/g, (_, key: string) => {
+    const value = params[key];
+    return value === undefined ? `{${key}}` : String(value);
+  });
+}

--- a/src/menu/title-menu.test.ts
+++ b/src/menu/title-menu.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { createNewSave } from "../save/model.js";
+import { createTranslator } from "../i18n/messages.js";
+import {
+  parseLocaleChoice,
+  parseTitleMenuAction,
+  renderLanguageOptions,
+  renderTitleMenu,
+} from "./title-menu.js";
+
+describe("title menu", () => {
+  it("renders planned menu slots for future new/load flows", () => {
+    const save = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+    const lines = renderTitleMenu(save, createTranslator("en"));
+
+    expect(lines.join("\n")).toContain("Start");
+    expect(lines.join("\n")).toContain("New Game");
+    expect(lines.join("\n")).toContain("Load Game");
+  });
+
+  it("parses start and options actions", () => {
+    expect(parseTitleMenuAction("")).toBe("start");
+    expect(parseTitleMenuAction("1")).toBe("start");
+    expect(parseTitleMenuAction("2")).toBe("options");
+  });
+
+  it("renders and parses language choices", () => {
+    const lines = renderLanguageOptions("en", createTranslator("en"));
+
+    expect(lines.join("\n")).toContain("日本語");
+    expect(parseLocaleChoice("2", "en")).toBe("ja");
+    expect(parseLocaleChoice("ja", "en")).toBe("ja");
+    expect(parseLocaleChoice("0", "ja")).toBe("ja");
+  });
+});

--- a/src/menu/title-menu.ts
+++ b/src/menu/title-menu.ts
@@ -1,0 +1,82 @@
+import {
+  SUPPORTED_LOCALES,
+  createTranslator,
+  localeDisplayName,
+  resolveLocale,
+  type LocaleId,
+  type Translator,
+} from "../i18n/messages.js";
+import type { KeyQuestSave } from "../save/model.js";
+
+export type TitleMenuAction = "start" | "options";
+
+export function renderTitleMenu(save: KeyQuestSave, translator: Translator): readonly string[] {
+  const hasExistingSession = save.progress.sessions.length > 0;
+  const firstAction = hasExistingSession
+    ? translator.t("title.menu.continue")
+    : translator.t("title.menu.start");
+
+  return [
+    translator.t("app.title"),
+    translator.t("app.subtitle"),
+    "",
+    translator.t("title.menu.heading"),
+    `1. ${firstAction}`,
+    `2. ${translator.t("title.menu.options")}`,
+    `3. ${translator.t("title.menu.newGame")} (${translator.t("title.menu.planned")})`,
+    `4. ${translator.t("title.menu.loadGame")} (${translator.t("title.menu.planned")})`,
+  ];
+}
+
+export function parseTitleMenuAction(input: string): TitleMenuAction {
+  const normalized = input.trim().toLowerCase();
+
+  if (
+    normalized === "" ||
+    normalized === "1" ||
+    normalized === "start" ||
+    normalized === "continue"
+  ) {
+    return "start";
+  }
+
+  if (normalized === "2" || normalized === "options" || normalized === "option") {
+    return "options";
+  }
+
+  return "start";
+}
+
+export function renderLanguageOptions(
+  currentLocale: LocaleId,
+  translator: Translator,
+): readonly string[] {
+  return [
+    translator.t("options.heading"),
+    `${translator.t("options.language")}: ${localeDisplayName(currentLocale)}`,
+    "",
+    ...SUPPORTED_LOCALES.map((locale, index) => `${index + 1}. ${localeDisplayName(locale)}`),
+    `0. ${translator.t("options.back")}`,
+  ];
+}
+
+export function parseLocaleChoice(input: string, currentLocale: LocaleId): LocaleId {
+  const normalized = input.trim();
+  if (normalized === "" || normalized === "0") {
+    return currentLocale;
+  }
+
+  const index = Number.parseInt(normalized, 10);
+  if (Number.isInteger(index) && index >= 1 && index <= SUPPORTED_LOCALES.length) {
+    const locale = SUPPORTED_LOCALES[index - 1];
+    if (locale !== undefined) {
+      return locale;
+    }
+  }
+
+  return resolveLocale(normalized);
+}
+
+export function createMenuTranslator(save: KeyQuestSave): Translator {
+  return createTranslator(save.settings.locale);
+}

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -1,3 +1,5 @@
+import type { LocaleId } from "../i18n/messages.js";
+
 export const SAVE_VERSION = 1;
 
 export type SaveMode = "normal" | "development";
@@ -34,7 +36,7 @@ export type KeyQuestSave = {
     readonly updatedAt: string;
   };
   readonly settings: {
-    readonly locale: string;
+    readonly locale: LocaleId;
     readonly colorMode: "auto" | "always" | "never";
     readonly theme: "classic" | "forest" | "arcane" | "ember" | "mono";
     readonly reducedMotion: boolean;
@@ -106,6 +108,20 @@ export function touchSave(save: KeyQuestSave, now: Date, mode: SaveMode): KeyQue
     development: {
       everUsedDevMode: save.development.everUsedDevMode || mode === "development",
       devSessions: save.development.devSessions,
+    },
+  };
+}
+
+export function updateLocale(save: KeyQuestSave, locale: LocaleId, now: Date): KeyQuestSave {
+  return {
+    ...save,
+    profile: {
+      ...save.profile,
+      updatedAt: now.toISOString(),
+    },
+    settings: {
+      ...save.settings,
+      locale,
     },
   };
 }

--- a/src/scenes/manager.test.ts
+++ b/src/scenes/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { createTranslator } from "../i18n/messages.js";
 import { createNewSave } from "../save/model.js";
 import { formatSceneSequence, renderSceneSequence } from "./manager.js";
 import { defaultScenes } from "./scenes.js";
@@ -14,6 +15,7 @@ describe("scene manager", () => {
         save: createNewSave(now, "normal"),
         mode: "normal",
         now,
+        translator: createTranslator("en"),
         lesson: {
           schemaVersion: 1,
           id: "novice-hall-day-1",

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -3,12 +3,14 @@ import type { PracticeResultView, Scene, SceneContext, SceneOutput } from "./typ
 export const titleScene: Scene = {
   id: "title",
   render(context: SceneContext): SceneOutput {
+    const { t } = context.translator;
+
     return {
       id: "title",
       lines: [
-        "KeyQuest",
-        "A terminal typing adventure for steady hands.",
-        context.mode === "development" ? "DEV MODE - debug magic is not sung by bards." : "",
+        t("app.title"),
+        t("app.subtitle"),
+        context.mode === "development" ? t("dev.banner") : "",
       ].filter((line) => line.length > 0),
       next: "story",
     };
@@ -18,13 +20,15 @@ export const titleScene: Scene = {
 export const storyScene: Scene = {
   id: "story",
   render(context: SceneContext): SceneOutput {
+    const { t } = context.translator;
+
     return {
       id: "story",
       lines: [
-        "Story",
+        t("story.heading"),
         `Day ${context.lesson.day}: ${context.lesson.title}`,
-        "The old instructor points to the home row.",
-        '"Before the blade, learn the stance."',
+        t("story.noviceIntro"),
+        t("story.noviceQuote"),
       ],
       next: "status",
     };
@@ -34,6 +38,7 @@ export const storyScene: Scene = {
 export const statusScene: Scene = {
   id: "status",
   render(context: SceneContext): SceneOutput {
+    const { t } = context.translator;
     const skills = context.save.progress.skills
       .slice(0, 3)
       .map((skill) => `${skill.id} Lv.${skill.level}`)
@@ -42,11 +47,11 @@ export const statusScene: Scene = {
     return {
       id: "status",
       lines: [
-        "Status",
-        `Hero: ${context.save.profile.heroName}`,
-        `XP: ${context.save.progress.totalXp}`,
-        `Streak: ${context.save.progress.streakDays} days`,
-        `Training: ${skills}`,
+        t("status.heading"),
+        t("status.hero", { hero: context.save.profile.heroName }),
+        t("status.xp", { xp: context.save.progress.totalXp }),
+        t("status.streak", { days: context.save.progress.streakDays }),
+        t("status.training", { skills }),
       ],
       next: "practiceIntro",
     };
@@ -57,16 +62,17 @@ export const practiceIntroScene: Scene = {
   id: "practiceIntro",
   render(context: SceneContext): SceneOutput {
     const { practicePrompt } = context;
+    const { t } = context.translator;
 
     return {
       id: "practiceIntro",
       lines: [
-        "Practice",
-        `Lesson: ${context.lesson.title}`,
-        "Keep your fingers on the home position.",
-        `Keys: ${practicePrompt.targetKeys.join(" ")}`,
-        `Fingers: ${practicePrompt.fingerHints.join(" / ")}`,
-        `Type: ${practicePrompt.text}`,
+        t("practice.heading"),
+        t("practice.lesson", { lesson: context.lesson.title }),
+        t("practice.homeHint"),
+        t("practice.keys", { keys: practicePrompt.targetKeys.join(" ") }),
+        t("practice.fingers", { fingers: practicePrompt.fingerHints.join(" / ") }),
+        t("practice.type", { text: practicePrompt.text }),
       ],
       next: "exit",
     };
@@ -80,21 +86,22 @@ export const defaultScenes: readonly Scene[] = [
   practiceIntroScene,
 ];
 
-export function renderPracticeResult(result: PracticeResultView): readonly string[] {
+export function renderPracticeResult(
+  result: PracticeResultView,
+  translator: SceneContext["translator"],
+): readonly string[] {
   const accuracy = Math.round(result.score.accuracy * 100);
-  const devLine =
-    result.mode === "development"
-      ? ["DEV MODE CLEAR - the bards refuse to sing about debug magic."]
-      : [];
+  const { t } = translator;
+  const devLine = result.mode === "development" ? [t("result.devClear")] : [];
 
   return [
-    "Result",
-    `Expected: ${result.prompt.text}`,
-    `Typed:    ${result.actual}`,
-    `Accuracy: ${accuracy}%`,
-    `WPM: ${result.score.wordsPerMinute.toFixed(1)}`,
-    `Mistakes: ${result.score.mistakes}`,
-    `XP gained: ${result.xpGained}`,
+    t("result.heading"),
+    t("result.expected", { text: result.prompt.text }),
+    t("result.typed", { text: result.actual }),
+    t("result.accuracy", { accuracy }),
+    t("result.wpm", { wpm: result.score.wordsPerMinute.toFixed(1) }),
+    t("result.mistakes", { mistakes: result.score.mistakes }),
+    t("result.xpGained", { xp: result.xpGained }),
     ...devLine,
   ];
 }

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -1,4 +1,5 @@
 import type { Score } from "../core/scoring.js";
+import type { Translator } from "../i18n/messages.js";
 import type { Lesson } from "../lessons/schema.js";
 import type { PracticePrompt } from "../practice/session.js";
 import type { KeyQuestSave, SaveMode } from "../save/model.js";
@@ -9,6 +10,7 @@ export type SceneContext = {
   readonly save: KeyQuestSave;
   readonly mode: SaveMode;
   readonly now: Date;
+  readonly translator: Translator;
   readonly lesson: Lesson;
   readonly practicePrompt: PracticePrompt;
 };


### PR DESCRIPTION
## Summary
- Add an in-repo i18n message catalog with supported locale IDs and catalog completeness tests.
- Add a title/options loop where players can choose a UI language before starting practice.
- Persist language changes in save data and localize scene/result UI strings while keeping typing prompts in English.

## Test plan
- npm run verify
- printf '2\n2\n1\nf j\n' | npm run dev -- --save-dir /tmp/keyquest-i18n-menu-2

Closes #8

Made with [Cursor](https://cursor.com)