### PR TITLE
Record character mistakes in sessions

### DIFF
--- a/docs/SAVE_DATA.md
+++ b/docs/SAVE_DATA.md
@@ -66,7 +66,7 @@ The save model should support:
 - 90-day journey progress
 - XP and skill tracks
 - HP, MP, items, weapons, magic, and materials
-- Weak-key statistics
+- Per-character mistake records for later weak-key statistics
 - Achievement unlocks
 - Dev-mode marker for sessions generated in development mode
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,7 @@
       breakpoints, and result timing.
 - [x] Add a session runner that can process multiple prompts before the final
       result screen.
-- [ ] Record per-character mistakes in session results for future weak-key
+- [x] Record per-character mistakes in session results for future weak-key
       review.
 - [ ] Clarify title menu semantics for current `Start` and future `Continue`,
       `New Game`, and `Load Game`.

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { createNewSave } from "../save/model.js";
-import { calculatePracticeXp, completePracticeRun, completePracticeSession } from "./session.js";
+import {
+  calculatePracticeXp,
+  collectCharacterMistakes,
+  completePracticeRun,
+  completePracticeSession,
+} from "./session.js";
 
 describe("completePracticeSession", () => {
   it("scores input and appends a session record", () => {
@@ -27,6 +32,7 @@ describe("completePracticeSession", () => {
     expect(result.updatedSave.progress.sessions).toHaveLength(1);
     expect(result.updatedSave.progress.totalXp).toBe(result.xpGained);
     expect(result.updatedSave.journey.storyFlag).toBe("noviceHallStarted");
+    expect(result.updatedSave.progress.sessions[0]?.mistakes).toEqual([]);
   });
 
   it("marks development sessions separately", () => {
@@ -93,6 +99,93 @@ describe("completePracticeRun", () => {
     expect(result.updatedSave.progress.sessions).toHaveLength(1);
     expect(result.updatedSave.progress.sessions[0]?.promptCount).toBe(2);
     expect(result.updatedSave.progress.totalXp).toBe(result.xpGained);
+    expect(result.updatedSave.progress.sessions[0]?.mistakes).toEqual([]);
+  });
+
+  it("aggregates mistake details across prompts", () => {
+    const startedAt = new Date("2026-01-01T00:00:00.000Z");
+    const secondStartedAt = new Date("2026-01-01T00:00:10.000Z");
+    const completedAt = new Date("2026-01-01T00:00:20.000Z");
+    const prompt = {
+      id: "home-row-1",
+      text: "f j",
+      skillIds: ["homePosition"] as const,
+      targetKeys: ["f", "j"],
+      fingerHints: ["leftIndex", "rightIndex"] as const,
+    };
+    const result = completePracticeRun({
+      save: createNewSave(startedAt, "normal"),
+      mode: "normal",
+      attempts: [
+        {
+          prompt,
+          actual: "f k",
+          startedAt,
+          completedAt: secondStartedAt,
+        },
+        {
+          prompt: {
+            ...prompt,
+            id: "home-row-2",
+            text: "ff",
+          },
+          actual: "f",
+          startedAt: secondStartedAt,
+          completedAt,
+        },
+      ],
+    });
+
+    expect(result.updatedSave.progress.sessions[0]?.mistakes).toEqual([
+      {
+        promptId: "home-row-1",
+        index: 2,
+        expected: "j",
+        actual: "k",
+      },
+      {
+        promptId: "home-row-2",
+        index: 1,
+        expected: "f",
+        actual: null,
+      },
+    ]);
+  });
+});
+
+describe("collectCharacterMistakes", () => {
+  const prompt = {
+    id: "home-row-1",
+    text: "f j",
+    skillIds: ["homePosition"] as const,
+    targetKeys: ["f", "j"],
+    fingerHints: ["leftIndex", "rightIndex"] as const,
+  };
+
+  it("records wrong, missing, and extra characters", () => {
+    expect(collectCharacterMistakes(prompt, "f kx")).toEqual([
+      {
+        promptId: "home-row-1",
+        index: 2,
+        expected: "j",
+        actual: "k",
+      },
+      {
+        promptId: "home-row-1",
+        index: 3,
+        expected: null,
+        actual: "x",
+      },
+    ]);
+
+    expect(collectCharacterMistakes(prompt, "f ")).toEqual([
+      {
+        promptId: "home-row-1",
+        index: 2,
+        expected: "j",
+        actual: null,
+      },
+    ]);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -1,5 +1,11 @@
 import { scoreTypingResult, type Score } from "../core/scoring.js";
-import type { KeyQuestSave, SaveMode, SessionRecord, SkillTrack } from "../save/model.js";
+import type {
+  CharacterMistakeRecord,
+  KeyQuestSave,
+  SaveMode,
+  SessionRecord,
+  SkillTrack,
+} from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
 
 export type PracticePrompt = {
@@ -14,6 +20,7 @@ export type PracticeSessionResult = {
   readonly prompt: PracticePrompt;
   readonly actual: string;
   readonly score: Score;
+  readonly mistakes: readonly CharacterMistakeRecord[];
   readonly xpGained: number;
   readonly updatedSave: KeyQuestSave;
 };
@@ -29,6 +36,7 @@ export type PracticeAttemptResult = {
   readonly prompt: PracticePrompt;
   readonly actual: string;
   readonly score: Score;
+  readonly mistakes: readonly CharacterMistakeRecord[];
   readonly xpGained: number;
 };
 
@@ -53,6 +61,7 @@ export function completePracticeSession(options: {
     startedAt: options.startedAt,
     completedAt: options.completedAt,
   });
+  const mistakes = collectCharacterMistakes(options.prompt, options.actual);
   const xpGained = calculatePracticeXp(score);
   const session: SessionRecord = {
     id: createSessionId(options.completedAt),
@@ -63,12 +72,14 @@ export function completePracticeSession(options: {
     accuracy: score.accuracy,
     wordsPerMinute: score.wordsPerMinute,
     xpGained,
+    mistakes,
   };
 
   return {
     prompt: options.prompt,
     actual: options.actual,
     score,
+    mistakes,
     xpGained,
     updatedSave: applyPracticeResult({
       save: options.save,
@@ -101,6 +112,7 @@ export function completePracticeRun(options: {
       prompt: attempt.prompt,
       actual: attempt.actual,
       score,
+      mistakes: collectCharacterMistakes(attempt.prompt, attempt.actual),
       xpGained: calculatePracticeXp(score),
     };
   });
@@ -121,6 +133,7 @@ export function completePracticeRun(options: {
     accuracy: score.accuracy,
     wordsPerMinute: score.wordsPerMinute,
     xpGained,
+    mistakes: attemptResults.flatMap((result) => result.mistakes),
   };
 
   return {
@@ -143,6 +156,32 @@ export function calculatePracticeXp(score: Score): number {
   const perfectBonus = score.mistakes === 0 && score.totalCharacters > 0 ? 10 : 0;
 
   return characterXp + accuracyBonus + perfectBonus;
+}
+
+export function collectCharacterMistakes(
+  prompt: PracticePrompt,
+  actual: string,
+): readonly CharacterMistakeRecord[] {
+  const mistakes: CharacterMistakeRecord[] = [];
+  const comparableLength = Math.max(prompt.text.length, actual.length);
+
+  for (let index = 0; index < comparableLength; index += 1) {
+    const expected = prompt.text[index];
+    const actualCharacter = actual[index];
+
+    if (expected === actualCharacter) {
+      continue;
+    }
+
+    mistakes.push({
+      promptId: prompt.id,
+      index,
+      expected: expected ?? null,
+      actual: actualCharacter ?? null,
+    });
+  }
+
+  return mistakes;
 }
 
 function applyPracticeResult(options: {

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -26,6 +26,14 @@ export type SessionRecord = {
   readonly accuracy: number;
   readonly wordsPerMinute: number;
   readonly xpGained: number;
+  readonly mistakes: readonly CharacterMistakeRecord[];
+};
+
+export type CharacterMistakeRecord = {
+  readonly promptId: string;
+  readonly index: number;
+  readonly expected: string | null;
+  readonly actual: string | null;
 };
 
 export type KeyQuestSave = {


### PR DESCRIPTION
## Summary
- Add per-character mistake records to saved session history.
- Record wrong, missing, and extra characters with prompt id and character index.
- Aggregate mistake records across multi-prompt practice runs.
- Update TODO and save-data docs for the weak-key review foundation.

## Test plan
- npm run verify
- printf '1\nf k\nff\nfj jx\n' | npm run dev -- --dev --save-dir /tmp/keyquest-mistake-records
- Read `/tmp/keyquest-mistake-records/save.dev.json` and verified saved `progress.sessions[-1].mistakes` entries.

Closes #33

Made with [Cursor](https://cursor.com)