### PR TITLE
Clarify title menu save actions

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,7 +8,7 @@
       result screen.
 - [x] Record per-character mistakes in session results for future weak-key
       review.
-- [ ] Clarify title menu semantics for current `Start` and future `Continue`,
+- [x] Clarify title menu semantics for current `Start` and future `Continue`,
       `New Game`, and `Load Game`.
 - [ ] Keep `main` green with `npm run verify`.
 

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -8,6 +8,7 @@ import { runApp } from "./app.js";
 import type { TextInput } from "./cli/text-input.js";
 import type { TextOutput } from "./cli/text-output.js";
 import type { Lesson } from "./lessons/schema.js";
+import { createSaveStore } from "./save/store.js";
 
 const tempDirectories: string[] = [];
 
@@ -103,6 +104,53 @@ describe("runApp", () => {
     expect(output.text()).toContain("ストーリー");
     expect(output.text()).toContain("時間: 20.0秒");
     expect(output.text()).toContain("セッション結果");
+  });
+
+  it("explains that load game is planned and returns to the title menu", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["4", "1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Load Game will open save slots later");
+    expect(output.text()).toContain("Session Result");
+  });
+
+  it("starts a new save when New Game is selected", async () => {
+    const directory = await createTempDirectory();
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: createMemoryOutput(),
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["3", "f j", "ff jj", "fj jf"]),
+      textOutput: createMemoryOutput(),
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-02T00:00:00.000Z"),
+      completedAt: new Date("2026-01-02T00:00:20.000Z"),
+    });
+
+    const save = await createSaveStore({ mode: "development", directory }).loadOrCreate(
+      new Date("2026-01-02T00:01:00.000Z"),
+    );
+    expect(save.progress.sessions).toHaveLength(1);
+    expect(save.profile.createdAt).toBe("2026-01-02T00:00:00.000Z");
   });
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import {
   renderTitleMenu,
 } from "./menu/title-menu.js";
 import { completePracticeRun, type PracticeAttempt } from "./practice/session.js";
-import { updateLocale, type KeyQuestSave, type SaveMode } from "./save/model.js";
+import { createNewSave, updateLocale, type KeyQuestSave, type SaveMode } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
 import {
@@ -155,6 +155,19 @@ async function runTitleMenu(options: {
     if (action === "start") {
       options.textOutput.writeLine("");
       return save;
+    }
+
+    if (action === "newGame") {
+      const newSave = createNewSave(options.now, options.mode);
+      await options.writeSave(newSave);
+      options.textOutput.writeLine("");
+      return newSave;
+    }
+
+    if (action === "loadGame") {
+      options.textOutput.writeLine(translator.t("title.menu.loadUnavailable"));
+      options.textOutput.writeLine("");
+      continue;
     }
 
     const selectedLocale = await runLanguageOptions({

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -21,6 +21,7 @@ const EN_MESSAGES = {
   "title.menu.start": "Start",
   "title.menu.prompt": "Choose: ",
   "title.menu.planned": "planned",
+  "title.menu.loadUnavailable": "Load Game will open save slots later. Use Continue for now.",
   "options.heading": "Options",
   "options.language": "Language",
   "options.back": "Back",
@@ -68,6 +69,8 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "スタート",
     "title.menu.prompt": "選択: ",
     "title.menu.planned": "予定",
+    "title.menu.loadUnavailable":
+      "ロードゲームは今後セーブスロットに対応します。今は「つづきから」を使ってください。",
     "options.heading": "オプション",
     "options.language": "言語",
     "options.back": "戻る",

--- a/src/menu/title-menu.test.ts
+++ b/src/menu/title-menu.test.ts
@@ -16,13 +16,15 @@ describe("title menu", () => {
 
     expect(lines.join("\n")).toContain("Start");
     expect(lines.join("\n")).toContain("New Game");
-    expect(lines.join("\n")).toContain("Load Game");
+    expect(lines.join("\n")).toContain("Load Game (planned)");
   });
 
-  it("parses start and options actions", () => {
+  it("parses title actions", () => {
     expect(parseTitleMenuAction("")).toBe("start");
     expect(parseTitleMenuAction("1")).toBe("start");
     expect(parseTitleMenuAction("2")).toBe("options");
+    expect(parseTitleMenuAction("3")).toBe("newGame");
+    expect(parseTitleMenuAction("4")).toBe("loadGame");
   });
 
   it("renders and parses language choices", () => {

--- a/src/menu/title-menu.ts
+++ b/src/menu/title-menu.ts
@@ -8,7 +8,7 @@ import {
 } from "../i18n/messages.js";
 import type { KeyQuestSave } from "../save/model.js";
 
-export type TitleMenuAction = "start" | "options";
+export type TitleMenuAction = "start" | "options" | "newGame" | "loadGame";
 
 export function renderTitleMenu(save: KeyQuestSave, translator: Translator): readonly string[] {
   const hasExistingSession = save.progress.sessions.length > 0;
@@ -23,7 +23,7 @@ export function renderTitleMenu(save: KeyQuestSave, translator: Translator): rea
     translator.t("title.menu.heading"),
     `1. ${firstAction}`,
     `2. ${translator.t("title.menu.options")}`,
-    `3. ${translator.t("title.menu.newGame")} (${translator.t("title.menu.planned")})`,
+    `3. ${translator.t("title.menu.newGame")}`,
     `4. ${translator.t("title.menu.loadGame")} (${translator.t("title.menu.planned")})`,
   ];
 }
@@ -42,6 +42,14 @@ export function parseTitleMenuAction(input: string): TitleMenuAction {
 
   if (normalized === "2" || normalized === "options" || normalized === "option") {
     return "options";
+  }
+
+  if (normalized === "3" || normalized === "new" || normalized === "new game") {
+    return "newGame";
+  }
+
+  if (normalized === "4" || normalized === "load" || normalized === "load game") {
+    return "loadGame";
   }
 
   return "start";


### PR DESCRIPTION
## Summary
- Make `New Game` create a fresh save before starting practice.
- Keep `Load Game` visible as a planned save-slot action and return players to the title menu with a clear message.
- Preserve Start/Continue and Options behavior, with tests for the new paths.
- Mark the related short-term TODO as complete.

## Test plan
- npm run verify
- printf '4\n1\nf j\nff jj\nfj jf\n' | npm run dev -- --save-dir /tmp/keyquest-load-planned
- printf '3\nf j\nff jj\nfj jf\n' | npm run dev -- --dev --save-dir /tmp/keyquest-new-game

Closes #35

Made with [Cursor](https://cursor.com)