### PR TITLE
Add terminal runtime boundary

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,7 +14,7 @@
 
 ## Next
 
-- [ ] Design the terminal UI runtime boundary for screen rendering, color, size,
+- [x] Design the terminal UI runtime boundary for screen rendering, color, size,
       and motion.
 - [ ] Add terminal capability detection for size and color support.
 - [ ] Add `--color`, `--no-color`, and reduced-motion option handling.

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import {
   renderPracticeRunResult,
   renderPracticeSegmentResult,
 } from "./scenes/scenes.js";
+import type { TerminalRuntime } from "./terminal/runtime.js";
 
 export type RunAppOptions = {
   readonly mode: SaveMode;
@@ -32,6 +33,7 @@ export type RunAppOptions = {
   readonly textOutput: TextOutput;
   readonly lesson: Lesson | undefined;
   readonly lessonPath: string | undefined;
+  readonly terminalRuntime?: TerminalRuntime;
   readonly now?: Date;
   readonly completedAt?: Date;
 };

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -18,7 +18,18 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--lesson=lessons/day-1.json"]).lessonPath).toBe("lessons/day-1.json");
   });
 
+  it("parses terminal runtime flags", () => {
+    expect(parseCliArgs(["--color", "always"]).colorMode).toBe("always");
+    expect(parseCliArgs(["--color=never"]).colorMode).toBe("never");
+    expect(parseCliArgs(["--no-color"]).colorMode).toBe("never");
+    expect(parseCliArgs(["--reduced-motion"]).reducedMotion).toBe(true);
+  });
+
   it("rejects unknown options", () => {
     expect(() => parseCliArgs(["--mystery"])).toThrow("Unknown option");
+  });
+
+  it("rejects unsupported color modes", () => {
+    expect(() => parseCliArgs(["--color", "sparkles"])).toThrow("Unsupported color mode");
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,13 +1,19 @@
+import { parseTerminalColorMode, type TerminalColorMode } from "../terminal/runtime.js";
+
 export type CliOptions = {
   readonly devMode: boolean;
   readonly saveDirectory: string | undefined;
   readonly lessonPath: string | undefined;
+  readonly colorMode: TerminalColorMode | undefined;
+  readonly reducedMotion: boolean;
 };
 
 export function parseCliArgs(args: readonly string[]): CliOptions {
   let devMode = false;
   let saveDirectory: string | undefined;
   let lessonPath: string | undefined;
+  let colorMode: TerminalColorMode | undefined;
+  let reducedMotion = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -17,6 +23,16 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
 
     if (arg === "--dev" || arg === "-dev") {
       devMode = true;
+      continue;
+    }
+
+    if (arg === "--reduced-motion") {
+      reducedMotion = true;
+      continue;
+    }
+
+    if (arg === "--no-color") {
+      colorMode = "never";
       continue;
     }
 
@@ -52,8 +68,24 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
       continue;
     }
 
+    if (arg === "--color") {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--color requires auto, always, or never");
+      }
+
+      colorMode = parseTerminalColorMode(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--color=")) {
+      colorMode = parseTerminalColorMode(arg.slice("--color=".length));
+      continue;
+    }
+
     throw new Error(`Unknown option: ${arg}`);
   }
 
-  return { devMode, saveDirectory, lessonPath };
+  return { devMode, saveDirectory, lessonPath, colorMode, reducedMotion };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { runApp } from "./app.js";
 import { parseCliArgs } from "./cli/args.js";
 import { createNodeTextInput } from "./cli/text-input.js";
 import { createNodeTextOutput } from "./cli/text-output.js";
+import { resolveTerminalRuntime } from "./terminal/runtime.js";
 
 try {
   const options = parseCliArgs(process.argv.slice(2));
@@ -12,12 +13,22 @@ try {
     output: process.stdout,
   });
   const textOutput = createNodeTextOutput(process.stdout);
+  const terminalRuntime = resolveTerminalRuntime({
+    colorMode: options.colorMode,
+    theme: undefined,
+    reducedMotion: options.reducedMotion,
+    columns: process.stdout.columns,
+    rows: process.stdout.rows,
+    isTty: process.stdout.isTTY === true,
+    env: process.env,
+  });
   try {
     await runApp({
       mode: options.devMode ? "development" : "normal",
       saveDirectory: options.saveDirectory,
       lesson: undefined,
       lessonPath: options.lessonPath,
+      terminalRuntime,
       textInput,
       textOutput,
     });

--- a/src/terminal/runtime.test.ts
+++ b/src/terminal/runtime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTerminalColorMode, resolveTerminalRuntime } from "./runtime.js";
+
+describe("terminal runtime", () => {
+  it("detects small terminals only when size is known", () => {
+    expect(
+      resolveTerminalRuntime({
+        colorMode: undefined,
+        theme: undefined,
+        reducedMotion: false,
+        columns: 79,
+        rows: 24,
+        isTty: true,
+        env: {},
+      }).size.isBelowMinimum,
+    ).toBe(true);
+    expect(
+      resolveTerminalRuntime({
+        colorMode: undefined,
+        theme: undefined,
+        reducedMotion: false,
+        columns: undefined,
+        rows: undefined,
+        isTty: true,
+        env: {},
+      }).size.isBelowMinimum,
+    ).toBe(false);
+  });
+
+  it("resolves color mode from CLI and environment", () => {
+    expect(
+      resolveTerminalRuntime({
+        colorMode: "never",
+        theme: undefined,
+        reducedMotion: false,
+        columns: 100,
+        rows: 30,
+        isTty: true,
+        env: { FORCE_COLOR: "1" },
+      }).colorEnabled,
+    ).toBe(false);
+    expect(
+      resolveTerminalRuntime({
+        colorMode: "auto",
+        theme: undefined,
+        reducedMotion: false,
+        columns: 100,
+        rows: 30,
+        isTty: true,
+        env: { NO_COLOR: "1" },
+      }).colorEnabled,
+    ).toBe(false);
+    expect(
+      resolveTerminalRuntime({
+        colorMode: "auto",
+        theme: undefined,
+        reducedMotion: false,
+        columns: 100,
+        rows: 30,
+        isTty: false,
+        env: { FORCE_COLOR: "1" },
+      }).colorEnabled,
+    ).toBe(true);
+  });
+
+  it("parses supported color modes", () => {
+    expect(parseTerminalColorMode("auto")).toBe("auto");
+    expect(parseTerminalColorMode("always")).toBe("always");
+    expect(parseTerminalColorMode("never")).toBe("never");
+    expect(() => parseTerminalColorMode("sometimes")).toThrow("Unsupported color mode");
+  });
+});

--- a/src/terminal/runtime.ts
+++ b/src/terminal/runtime.ts
@@ -1,0 +1,85 @@
+export type TerminalColorMode = "auto" | "always" | "never";
+
+export type TerminalThemeId = "classic" | "forest" | "arcane" | "ember" | "mono";
+
+export type TerminalSize = {
+  readonly columns: number | undefined;
+  readonly rows: number | undefined;
+  readonly isBelowMinimum: boolean;
+};
+
+export type TerminalRuntime = {
+  readonly colorMode: TerminalColorMode;
+  readonly colorEnabled: boolean;
+  readonly theme: TerminalThemeId;
+  readonly reducedMotion: boolean;
+  readonly size: TerminalSize;
+};
+
+export type TerminalRuntimeOptions = {
+  readonly colorMode: TerminalColorMode | undefined;
+  readonly theme: TerminalThemeId | undefined;
+  readonly reducedMotion: boolean;
+  readonly columns: number | undefined;
+  readonly rows: number | undefined;
+  readonly isTty: boolean;
+  readonly env: Readonly<Record<string, string | undefined>>;
+};
+
+const MINIMUM_COLUMNS = 80;
+const MINIMUM_ROWS = 24;
+
+export function resolveTerminalRuntime(options: TerminalRuntimeOptions): TerminalRuntime {
+  const colorMode = options.colorMode ?? "auto";
+
+  return {
+    colorMode,
+    colorEnabled: resolveColorEnabled(colorMode, options),
+    theme: options.theme ?? "classic",
+    reducedMotion: options.reducedMotion || options.env["KEYQUEST_REDUCED_MOTION"] === "1",
+    size: {
+      columns: options.columns,
+      rows: options.rows,
+      isBelowMinimum: isBelowMinimumSize(options.columns, options.rows),
+    },
+  };
+}
+
+export function parseTerminalColorMode(value: string): TerminalColorMode {
+  if (value === "auto" || value === "always" || value === "never") {
+    return value;
+  }
+
+  throw new Error(`Unsupported color mode: ${value}`);
+}
+
+function resolveColorEnabled(
+  colorMode: TerminalColorMode,
+  options: TerminalRuntimeOptions,
+): boolean {
+  if (colorMode === "never") {
+    return false;
+  }
+
+  if (colorMode === "always") {
+    return true;
+  }
+
+  if (options.env["NO_COLOR"] !== undefined) {
+    return false;
+  }
+
+  if (options.env["FORCE_COLOR"] !== undefined) {
+    return true;
+  }
+
+  return options.isTty;
+}
+
+function isBelowMinimumSize(columns: number | undefined, rows: number | undefined): boolean {
+  if (columns === undefined || rows === undefined) {
+    return false;
+  }
+
+  return columns < MINIMUM_COLUMNS || rows < MINIMUM_ROWS;
+}


### PR DESCRIPTION
## Summary
- Add `src/terminal/runtime.ts` for terminal size, color, theme, and reduced-motion decisions.
- Parse `--color`, `--no-color`, and `--reduced-motion` CLI flags.
- Wire runtime resolution through the CLI entry point without changing current rendering behavior yet.
- Mark the terminal runtime boundary TODO as complete.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --no-color --reduced-motion --save-dir /tmp/keyquest-runtime-flags

Closes #37

Made with [Cursor](https://cursor.com)