### PR TITLE
Warn on small terminal sizes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,8 +16,8 @@
 
 - [x] Design the terminal UI runtime boundary for screen rendering, color, size,
       and motion.
-- [ ] Add terminal capability detection for size and color support.
-- [ ] Add `--color`, `--no-color`, and reduced-motion option handling.
+- [x] Add terminal capability detection for size and color support.
+- [x] Add `--color`, `--no-color`, and reduced-motion option handling.
 - [ ] Add five semantic color themes: classic, forest, arcane, ember, and mono.
 - [ ] Build a one-prompt raw-mode typing spike behind a testable state machine.
 - [ ] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -40,6 +40,60 @@ describe("runApp", () => {
     expect(output.text()).toContain("XP gained");
   });
 
+  it("warns when the terminal is below the recommended size", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      terminalRuntime: {
+        colorMode: "auto",
+        colorEnabled: true,
+        theme: "classic",
+        reducedMotion: false,
+        size: {
+          columns: 79,
+          rows: 24,
+          isBelowMinimum: true,
+        },
+      },
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("WARNING: Terminal is 79x24");
+  });
+
+  it("does not warn when terminal size is unknown", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      terminalRuntime: {
+        colorMode: "auto",
+        colorEnabled: true,
+        theme: "classic",
+        reducedMotion: false,
+        size: {
+          columns: undefined,
+          rows: undefined,
+          isBelowMinimum: false,
+        },
+      },
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).not.toContain("WARNING: Terminal");
+  });
+
   it("marks development mode visibly", async () => {
     const output = createMemoryOutput();
     await runApp({

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,13 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     ...(options.saveDirectory === undefined ? {} : { directory: options.saveDirectory }),
   });
   const save = await saveStore.loadOrCreate(now);
+  const initialTranslator = createTranslator(save.settings.locale);
+  const terminalWarnings = renderTerminalWarnings(options.terminalRuntime, initialTranslator);
+  if (terminalWarnings.length > 0) {
+    options.textOutput.writeLine(terminalWarnings.join("\n"));
+    options.textOutput.writeLine("");
+  }
+
   const menuSave = await runTitleMenu({
     save,
     mode: options.mode,
@@ -203,4 +210,20 @@ async function runLanguageOptions(options: {
   options.textOutput.writeLine("");
 
   return selectedLocale;
+}
+
+function renderTerminalWarnings(
+  terminalRuntime: TerminalRuntime | undefined,
+  translator: ReturnType<typeof createTranslator>,
+): readonly string[] {
+  if (terminalRuntime?.size.isBelowMinimum !== true) {
+    return [];
+  }
+
+  return [
+    translator.t("terminal.sizeWarning", {
+      columns: terminalRuntime.size.columns ?? "?",
+      rows: terminalRuntime.size.rows ?? "?",
+    }),
+  ];
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -22,6 +22,7 @@ const EN_MESSAGES = {
   "title.menu.prompt": "Choose: ",
   "title.menu.planned": "planned",
   "title.menu.loadUnavailable": "Load Game will open save slots later. Use Continue for now.",
+  "terminal.sizeWarning": "WARNING: Terminal is {columns}x{rows}. Recommended minimum is 80x24.",
   "options.heading": "Options",
   "options.language": "Language",
   "options.back": "Back",
@@ -71,6 +72,8 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.planned": "予定",
     "title.menu.loadUnavailable":
       "ロードゲームは今後セーブスロットに対応します。今は「つづきから」を使ってください。",
+    "terminal.sizeWarning":
+      "WARNING: 端末サイズは {columns}x{rows} です。推奨最小サイズは 80x24 です。",
     "options.heading": "オプション",
     "options.language": "言語",
     "options.back": "戻る",


### PR DESCRIPTION
## Summary
- Display a localized warning when terminal runtime reports a size below 80x24.
- Keep unknown-size environments quiet to avoid CI or piped-output noise.
- Mark initial terminal capability and CLI runtime flag TODOs as complete.

## Test plan
- npm run verify

Closes #39

Made with [Cursor](https://cursor.com)