### PR TITLE
Add semantic terminal themes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,7 +18,7 @@
       and motion.
 - [x] Add terminal capability detection for size and color support.
 - [x] Add `--color`, `--no-color`, and reduced-motion option handling.
-- [ ] Add five semantic color themes: classic, forest, arcane, ember, and mono.
+- [x] Add five semantic color themes: classic, forest, arcane, ember, and mono.
 - [ ] Build a one-prompt raw-mode typing spike behind a testable state machine.
 - [ ] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
 - [ ] Add a first reward screen with skill XP and a simple level-up message.

--- a/src/terminal/runtime.ts
+++ b/src/terminal/runtime.ts
@@ -1,6 +1,6 @@
-export type TerminalColorMode = "auto" | "always" | "never";
+import { resolveTerminalTheme, type TerminalThemeId } from "./theme.js";
 
-export type TerminalThemeId = "classic" | "forest" | "arcane" | "ember" | "mono";
+export type TerminalColorMode = "auto" | "always" | "never";
 
 export type TerminalSize = {
   readonly columns: number | undefined;
@@ -31,11 +31,12 @@ const MINIMUM_ROWS = 24;
 
 export function resolveTerminalRuntime(options: TerminalRuntimeOptions): TerminalRuntime {
   const colorMode = options.colorMode ?? "auto";
+  const theme = resolveTerminalTheme(options.theme);
 
   return {
     colorMode,
     colorEnabled: resolveColorEnabled(colorMode, options),
-    theme: options.theme ?? "classic",
+    theme: theme.id,
     reducedMotion: options.reducedMotion || options.env["KEYQUEST_REDUCED_MOTION"] === "1",
     size: {
       columns: options.columns,

--- a/src/terminal/theme.test.ts
+++ b/src/terminal/theme.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TERMINAL_COLOR_TOKENS,
+  TERMINAL_THEME_IDS,
+  TERMINAL_THEMES,
+  resolveTerminalTheme,
+} from "./theme.js";
+
+describe("terminal themes", () => {
+  it("defines the initial theme set", () => {
+    expect(TERMINAL_THEME_IDS).toEqual(["classic", "forest", "arcane", "ember", "mono"]);
+  });
+
+  it("keeps every theme on the same semantic token set", () => {
+    for (const themeId of TERMINAL_THEME_IDS) {
+      expect(Object.keys(TERMINAL_THEMES[themeId].colors).sort()).toEqual(
+        [...TERMINAL_COLOR_TOKENS].sort(),
+      );
+    }
+  });
+
+  it("falls back to classic for unknown theme ids", () => {
+    expect(resolveTerminalTheme("unknown").id).toBe("classic");
+    expect(resolveTerminalTheme("arcane").id).toBe("arcane");
+  });
+});

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -1,0 +1,156 @@
+export const TERMINAL_THEME_IDS = ["classic", "forest", "arcane", "ember", "mono"] as const;
+
+export const TERMINAL_COLOR_TOKENS = [
+  "background",
+  "foreground",
+  "muted",
+  "accent",
+  "success",
+  "warning",
+  "danger",
+  "hp",
+  "mp",
+  "xp",
+  "prompt",
+  "typedCorrect",
+  "typedWrong",
+  "cursor",
+] as const;
+
+export type TerminalThemeId = (typeof TERMINAL_THEME_IDS)[number];
+
+export type TerminalColorToken = (typeof TERMINAL_COLOR_TOKENS)[number];
+
+export type TerminalColorName =
+  | "black"
+  | "blue"
+  | "cyan"
+  | "green"
+  | "magenta"
+  | "red"
+  | "white"
+  | "yellow"
+  | "brightBlack"
+  | "brightBlue"
+  | "brightCyan"
+  | "brightGreen"
+  | "brightMagenta"
+  | "brightRed"
+  | "brightWhite"
+  | "brightYellow"
+  | "default";
+
+export type TerminalTheme = {
+  readonly id: TerminalThemeId;
+  readonly colors: Readonly<Record<TerminalColorToken, TerminalColorName>>;
+};
+
+export const TERMINAL_THEMES: Readonly<Record<TerminalThemeId, TerminalTheme>> = {
+  classic: {
+    id: "classic",
+    colors: {
+      background: "default",
+      foreground: "white",
+      muted: "brightBlack",
+      accent: "brightYellow",
+      success: "green",
+      warning: "yellow",
+      danger: "red",
+      hp: "brightRed",
+      mp: "brightBlue",
+      xp: "brightYellow",
+      prompt: "brightWhite",
+      typedCorrect: "green",
+      typedWrong: "red",
+      cursor: "brightWhite",
+    },
+  },
+  forest: {
+    id: "forest",
+    colors: {
+      background: "default",
+      foreground: "brightWhite",
+      muted: "brightBlack",
+      accent: "yellow",
+      success: "brightGreen",
+      warning: "brightYellow",
+      danger: "red",
+      hp: "red",
+      mp: "cyan",
+      xp: "yellow",
+      prompt: "green",
+      typedCorrect: "brightGreen",
+      typedWrong: "brightRed",
+      cursor: "brightYellow",
+    },
+  },
+  arcane: {
+    id: "arcane",
+    colors: {
+      background: "default",
+      foreground: "brightWhite",
+      muted: "brightBlack",
+      accent: "brightMagenta",
+      success: "brightCyan",
+      warning: "brightYellow",
+      danger: "brightRed",
+      hp: "magenta",
+      mp: "brightCyan",
+      xp: "brightMagenta",
+      prompt: "brightBlue",
+      typedCorrect: "cyan",
+      typedWrong: "brightRed",
+      cursor: "brightCyan",
+    },
+  },
+  ember: {
+    id: "ember",
+    colors: {
+      background: "default",
+      foreground: "brightWhite",
+      muted: "brightBlack",
+      accent: "brightRed",
+      success: "brightGreen",
+      warning: "brightYellow",
+      danger: "red",
+      hp: "brightRed",
+      mp: "brightYellow",
+      xp: "yellow",
+      prompt: "brightYellow",
+      typedCorrect: "brightGreen",
+      typedWrong: "red",
+      cursor: "brightRed",
+    },
+  },
+  mono: {
+    id: "mono",
+    colors: {
+      background: "default",
+      foreground: "white",
+      muted: "brightBlack",
+      accent: "brightWhite",
+      success: "white",
+      warning: "brightWhite",
+      danger: "white",
+      hp: "white",
+      mp: "white",
+      xp: "brightWhite",
+      prompt: "brightWhite",
+      typedCorrect: "white",
+      typedWrong: "brightWhite",
+      cursor: "brightWhite",
+    },
+  },
+};
+
+export function resolveTerminalTheme(themeId: string | undefined): TerminalTheme {
+  if (themeId !== undefined && isTerminalThemeId(themeId)) {
+    return TERMINAL_THEMES[themeId];
+  }
+
+  return TERMINAL_THEMES.classic;
+}
+
+export function isTerminalThemeId(themeId: string): themeId is TerminalThemeId {
+  return TERMINAL_THEME_IDS.includes(themeId as TerminalThemeId);
+}


### PR DESCRIPTION
## Summary
- Add classic, forest, arcane, ember, and mono terminal themes.
- Define shared semantic color tokens from the UI spec.
- Make runtime theme resolution fall back to classic for unknown ids.
- Mark the initial theme TODO as complete.

## Test plan
- npm run verify

Closes #41

Made with [Cursor](https://cursor.com)