### PR TITLE
Add realtime typing state machine

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,7 +19,7 @@
 - [x] Add terminal capability detection for size and color support.
 - [x] Add `--color`, `--no-color`, and reduced-motion option handling.
 - [x] Add five semantic color themes: classic, forest, arcane, ember, and mono.
-- [ ] Build a one-prompt raw-mode typing spike behind a testable state machine.
+- [x] Build a one-prompt raw-mode typing spike behind a testable state machine.
 - [ ] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
 - [ ] Add a first reward screen with skill XP and a simple level-up message.
 - [ ] Draft the first 7-day training cycle.

--- a/src/realtime/typing-state.test.ts
+++ b/src/realtime/typing-state.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { applyTypingInput, createTypingState, deriveTypingCharacterViews } from "./typing-state.js";
+
+describe("typing state", () => {
+  it("appends characters and derives correct/wrong/pending views", () => {
+    const state = applyTypingInput(
+      applyTypingInput(createTypingState("f j"), { kind: "character", value: "f" }),
+      { kind: "character", value: "x" },
+    );
+
+    expect(state.actual).toBe("fx");
+    expect(deriveTypingCharacterViews(state)).toEqual([
+      {
+        index: 0,
+        expected: "f",
+        actual: "f",
+        state: "correct",
+      },
+      {
+        index: 1,
+        expected: " ",
+        actual: "x",
+        state: "wrong",
+      },
+      {
+        index: 2,
+        expected: "j",
+        actual: null,
+        state: "pending",
+      },
+    ]);
+  });
+
+  it("handles backspace without leaving active state", () => {
+    const typed = applyTypingInput(createTypingState("ff"), { kind: "character", value: "f" });
+    const backed = applyTypingInput(typed, { kind: "backspace" });
+
+    expect(backed).toEqual({
+      expected: "ff",
+      actual: "",
+      status: "active",
+    });
+  });
+
+  it("marks extra typed characters", () => {
+    const state = applyTypingInput(createTypingState("f"), { kind: "character", value: "x" });
+    const extra = applyTypingInput(state, { kind: "character", value: "x" });
+
+    expect(deriveTypingCharacterViews(extra)).toEqual([
+      {
+        index: 0,
+        expected: "f",
+        actual: "x",
+        state: "wrong",
+      },
+      {
+        index: 1,
+        expected: null,
+        actual: "x",
+        state: "extra",
+      },
+    ]);
+  });
+
+  it("handles submit and cancel as terminal states", () => {
+    const completed = applyTypingInput(createTypingState("f"), { kind: "submit" });
+    const ignoredAfterComplete = applyTypingInput(completed, { kind: "character", value: "f" });
+    const cancelled = applyTypingInput(createTypingState("f"), { kind: "cancel" });
+
+    expect(completed.status).toBe("completed");
+    expect(ignoredAfterComplete.actual).toBe("");
+    expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("rejects multi-character input events", () => {
+    expect(() =>
+      applyTypingInput(createTypingState("f"), { kind: "character", value: "ff" }),
+    ).toThrow("exactly one character");
+  });
+});

--- a/src/realtime/typing-state.ts
+++ b/src/realtime/typing-state.ts
@@ -1,0 +1,109 @@
+export type TypingInput =
+  | {
+      readonly kind: "character";
+      readonly value: string;
+    }
+  | {
+      readonly kind: "backspace";
+    }
+  | {
+      readonly kind: "submit";
+    }
+  | {
+      readonly kind: "cancel";
+    };
+
+export type TypingRunStatus = "active" | "completed" | "cancelled";
+
+export type TypingCharacterState = "pending" | "correct" | "wrong" | "extra";
+
+export type TypingCharacterView = {
+  readonly index: number;
+  readonly expected: string | null;
+  readonly actual: string | null;
+  readonly state: TypingCharacterState;
+};
+
+export type TypingState = {
+  readonly expected: string;
+  readonly actual: string;
+  readonly status: TypingRunStatus;
+};
+
+export function createTypingState(expected: string): TypingState {
+  return {
+    expected,
+    actual: "",
+    status: "active",
+  };
+}
+
+export function applyTypingInput(state: TypingState, input: TypingInput): TypingState {
+  if (state.status !== "active") {
+    return state;
+  }
+
+  if (input.kind === "cancel") {
+    return {
+      ...state,
+      status: "cancelled",
+    };
+  }
+
+  if (input.kind === "submit") {
+    return {
+      ...state,
+      status: "completed",
+    };
+  }
+
+  if (input.kind === "backspace") {
+    return {
+      ...state,
+      actual: state.actual.slice(0, -1),
+    };
+  }
+
+  if (input.value.length !== 1) {
+    throw new Error("Character input must contain exactly one character");
+  }
+
+  return {
+    ...state,
+    actual: `${state.actual}${input.value}`,
+  };
+}
+
+export function deriveTypingCharacterViews(state: TypingState): readonly TypingCharacterView[] {
+  const length = Math.max(state.expected.length, state.actual.length);
+  const views: TypingCharacterView[] = [];
+
+  for (let index = 0; index < length; index += 1) {
+    const expected = state.expected[index] ?? null;
+    const actual = state.actual[index] ?? null;
+
+    views.push({
+      index,
+      expected,
+      actual,
+      state: deriveCharacterState(expected, actual),
+    });
+  }
+
+  return views;
+}
+
+function deriveCharacterState(
+  expected: string | null,
+  actual: string | null,
+): TypingCharacterState {
+  if (expected === null) {
+    return "extra";
+  }
+
+  if (actual === null) {
+    return "pending";
+  }
+
+  return expected === actual ? "correct" : "wrong";
+}


### PR DESCRIPTION
## Summary
- Add a pure one-prompt typing state machine for character, backspace, submit, and cancel inputs.
- Derive correct, wrong, pending, and extra character views for future realtime rendering.
- Mark the raw-mode spike state-machine TODO as complete.

## Test plan
- npm run verify

Closes #43

Made with [Cursor](https://cursor.com)