### PR TITLE
Add raw mode cleanup helpers

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,7 +20,7 @@
 - [x] Add `--color`, `--no-color`, and reduced-motion option handling.
 - [x] Add five semantic color themes: classic, forest, arcane, ember, and mono.
 - [x] Build a one-prompt raw-mode typing spike behind a testable state machine.
-- [ ] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
+- [x] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
 - [ ] Add a first reward screen with skill XP and a simple level-up message.
 - [ ] Draft the first 7-day training cycle.
 

--- a/src/realtime/raw-mode.test.ts
+++ b/src/realtime/raw-mode.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { toTypingInputFromKey, withRawMode, type RawModeStream } from "./raw-mode.js";
+
+describe("raw mode helpers", () => {
+  it("restores raw mode after successful runs", async () => {
+    const calls: string[] = [];
+    const stream = createFakeRawModeStream(calls);
+
+    const result = await withRawMode(stream, () => "ok");
+
+    expect(result).toBe("ok");
+    expect(calls).toEqual(["raw:true", "resume", "raw:false", "pause"]);
+  });
+
+  it("restores raw mode after throwing runs", async () => {
+    const calls: string[] = [];
+    const stream = createFakeRawModeStream(calls);
+
+    await expect(
+      withRawMode(stream, () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(calls).toEqual(["raw:true", "resume", "raw:false", "pause"]);
+  });
+
+  it("ignores non-TTY streams", async () => {
+    const calls: string[] = [];
+    const stream: RawModeStream = {
+      isTTY: false,
+      setRawMode(enabled: boolean): void {
+        calls.push(`raw:${enabled}`);
+      },
+    };
+
+    await withRawMode(stream, () => "ok");
+
+    expect(calls).toEqual([]);
+  });
+
+  it("maps terminal keys to typing inputs", () => {
+    expect(toTypingInputFromKey("\u0003")).toEqual({ kind: "cancel" });
+    expect(toTypingInputFromKey("\r")).toEqual({ kind: "submit" });
+    expect(toTypingInputFromKey("\u007f")).toEqual({ kind: "backspace" });
+    expect(toTypingInputFromKey("f")).toEqual({ kind: "character", value: "f" });
+    expect(toTypingInputFromKey("\u001b[A")).toBeUndefined();
+  });
+});
+
+function createFakeRawModeStream(calls: string[]): RawModeStream {
+  return {
+    isTTY: true,
+    setRawMode(enabled: boolean): void {
+      calls.push(`raw:${enabled}`);
+    },
+    resume(): void {
+      calls.push("resume");
+    },
+    pause(): void {
+      calls.push("pause");
+    },
+  };
+}

--- a/src/realtime/raw-mode.ts
+++ b/src/realtime/raw-mode.ts
@@ -1,0 +1,50 @@
+import type { TypingInput } from "./typing-state.js";
+
+export type RawModeStream = {
+  readonly isTTY?: boolean;
+  readonly setRawMode?: (enabled: boolean) => void;
+  readonly resume?: () => void;
+  readonly pause?: () => void;
+};
+
+export async function withRawMode<T>(stream: RawModeStream, run: () => Promise<T> | T): Promise<T> {
+  const setRawMode = stream.setRawMode;
+  const shouldUseRawMode = stream.isTTY === true && setRawMode !== undefined;
+
+  if (!shouldUseRawMode) {
+    return run();
+  }
+
+  setRawMode(true);
+  stream.resume?.();
+
+  try {
+    return await run();
+  } finally {
+    setRawMode(false);
+    stream.pause?.();
+  }
+}
+
+export function toTypingInputFromKey(key: string): TypingInput | undefined {
+  if (key === "\u0003") {
+    return { kind: "cancel" };
+  }
+
+  if (key === "\r" || key === "\n") {
+    return { kind: "submit" };
+  }
+
+  if (key === "\u007f" || key === "\b") {
+    return { kind: "backspace" };
+  }
+
+  if (key.length === 1) {
+    return {
+      kind: "character",
+      value: key,
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Add `withRawMode` to enable raw mode only for TTY streams and restore it in `finally`.
- Map Ctrl+C, Enter, Backspace, and character keys to typing inputs.
- Mark the raw-mode cleanup TODO as complete.

## Test plan
- npm run verify

Closes #45

Made with [Cursor](https://cursor.com)