### PR TITLE
Add first reward screen

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,7 @@
 - [x] Add five semantic color themes: classic, forest, arcane, ember, and mono.
 - [x] Build a one-prompt raw-mode typing spike behind a testable state machine.
 - [x] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
-- [ ] Add a first reward screen with skill XP and a simple level-up message.
+- [x] Add a first reward screen with skill XP and a simple level-up message.
 - [ ] Draft the first 7-day training cycle.
 
 ## Mid Term

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -38,6 +38,7 @@ describe("runApp", () => {
     expect(output.text()).toContain("Session Result");
     expect(output.text()).toContain("Time: 20.0s");
     expect(output.text()).toContain("XP gained");
+    expect(output.text()).toContain("Rewards");
   });
 
   it("warns when the terminal is below the recommended size", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import {
   defaultScenes,
   practiceIntroScene,
   renderPracticeRunResult,
+  renderPracticeRewards,
   renderPracticeSegmentResult,
 } from "./scenes/scenes.js";
 import type { TerminalRuntime } from "./terminal/runtime.js";
@@ -135,6 +136,16 @@ export async function runApp(options: RunAppOptions): Promise<void> {
         score: result.score,
         xpGained: result.xpGained,
         mode: options.mode,
+      },
+      translator,
+    ).join("\n"),
+  );
+  options.textOutput.writeLine("");
+  options.textOutput.writeLine(
+    renderPracticeRewards(
+      {
+        beforeSave: menuSave,
+        afterSave: result.updatedSave,
       },
       translator,
     ).join("\n"),

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -54,6 +54,9 @@ const EN_MESSAGES = {
   "result.mistakes": "Mistakes: {mistakes}",
   "result.xpGained": "XP gained: {xp}",
   "result.devClear": "DEV MODE CLEAR - the bards refuse to sing about debug magic.",
+  "reward.heading": "Rewards",
+  "reward.skillXp": "{skill}: +{xp} XP (Lv.{level})",
+  "reward.levelUp": "Level up: {skill} Lv.{level}",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -105,6 +108,9 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "result.mistakes": "ミス: {mistakes}",
     "result.xpGained": "獲得XP: {xp}",
     "result.devClear": "DEV MODE CLEAR - デバッグ魔法なので少しだけ残念なクリアです。",
+    "reward.heading": "報酬",
+    "reward.skillXp": "{skill}: +{xp} XP (Lv.{level})",
+    "reward.levelUp": "レベルアップ: {skill} Lv.{level}",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { createTranslator } from "../i18n/messages.js";
+import { createNewSave } from "../save/model.js";
+import { renderPracticeRewards } from "./scenes.js";
+
+describe("scene rendering", () => {
+  it("renders skill XP and level-up rewards", () => {
+    const beforeSave = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+    const afterSave = {
+      ...beforeSave,
+      progress: {
+        ...beforeSave.progress,
+        skills: beforeSave.progress.skills.map((skill) =>
+          skill.id === "homePosition"
+            ? {
+                ...skill,
+                xp: 100,
+                level: 2,
+              }
+            : skill,
+        ),
+      },
+    };
+
+    expect(
+      renderPracticeRewards(
+        {
+          beforeSave,
+          afterSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Rewards", "homePosition: +100 XP (Lv.2)", "Level up: homePosition Lv.2"]);
+  });
+});

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,4 +1,5 @@
 import type {
+  PracticeRewardsView,
   PracticeResultView,
   PracticeRunResultView,
   Scene,
@@ -151,6 +152,45 @@ export function renderPracticeRunResult(
     t("result.xpGained", { xp: result.xpGained }),
     ...devLine,
   ];
+}
+
+export function renderPracticeRewards(
+  rewards: PracticeRewardsView,
+  translator: SceneContext["translator"],
+): readonly string[] {
+  const { t } = translator;
+  const rewardLines = rewards.afterSave.progress.skills.flatMap((afterSkill) => {
+    const beforeSkill = rewards.beforeSave.progress.skills.find(
+      (skill) => skill.id === afterSkill.id,
+    );
+    if (beforeSkill === undefined) {
+      return [];
+    }
+
+    const xpGained = afterSkill.xp - beforeSkill.xp;
+    if (xpGained <= 0) {
+      return [];
+    }
+
+    const skillLine = t("reward.skillXp", {
+      skill: afterSkill.id,
+      xp: xpGained,
+      level: afterSkill.level,
+    });
+    const levelLine =
+      afterSkill.level > beforeSkill.level
+        ? [
+            t("reward.levelUp", {
+              skill: afterSkill.id,
+              level: afterSkill.level,
+            }),
+          ]
+        : [];
+
+    return [skillLine, ...levelLine];
+  });
+
+  return [t("reward.heading"), ...rewardLines];
 }
 
 function formatElapsedSeconds(elapsedSeconds: number): string {

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -40,3 +40,8 @@ export type PracticeRunResultView = {
   readonly xpGained: number;
   readonly mode: SaveMode;
 };
+
+export type PracticeRewardsView = {
+  readonly beforeSave: KeyQuestSave;
+  readonly afterSave: KeyQuestSave;
+};


### PR DESCRIPTION
## Summary
- Add a localized reward section after session results.
- Show skill XP gains for trained tracks and simple level-up messages.
- Mark the first reward screen TODO as complete.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --save-dir /tmp/keyquest-rewards

Closes #47

Made with [Cursor](https://cursor.com)