### PR TITLE
Draft first week training cycle

### DIFF
--- a/docs/ONBOARDING_TRAINING.md
+++ b/docs/ONBOARDING_TRAINING.md
@@ -32,6 +32,78 @@ The first week is the "Novice Hall" arc.
 The first boss should reward patience. Passing with high accuracy should matter
 more than typing quickly.
 
+### Day 1: Novice Stance
+
+Player goal: learn that good typing starts from calm finger placement.
+
+- Key focus: `f`, `j`, `a`, `s`, `d`, `k`, `l`, `;`.
+- Prompt style: tiny pairs, mirrored pairs, and one short home-row mix.
+- Review intent: catch early index-finger confusion and rushed spacing.
+- RPG framing: the old instructor teaches the hero's first stance.
+- Reward intent: small Home Position and Finger Responsibility XP.
+
+### Day 2: Left And Right Balance
+
+Player goal: stop favoring one hand and build even rhythm.
+
+- Key focus: alternating left/right home-row patterns.
+- Prompt style: `asdf`, `jkl;`, mirrored chunks, and short alternation drills.
+- Review intent: identify side-specific hesitation.
+- RPG framing: two training dummies must be struck evenly.
+- Reward intent: Rhythm XP starts to matter, but accuracy remains primary.
+
+### Day 3: Finger Responsibility
+
+Player goal: understand which finger owns each home-row key.
+
+- Key focus: same-row movement without hand drift.
+- Prompt style: repeated responsible-finger drills and short correction prompts.
+- Review intent: catch wrong-finger patterns before they become habits.
+- RPG framing: each finger becomes a trainee guard assigned to a gate.
+- Reward intent: Finger Responsibility XP is highlighted in the reward screen.
+
+### Day 4: Rhythm Hall
+
+Player goal: type familiar home-row patterns with a stable cadence.
+
+- Key focus: repeated home-row combinations and spacing.
+- Prompt style: short rhythmic chunks, no long prose yet.
+- Review intent: separate rhythm mistakes from unknown-key mistakes.
+- RPG framing: the hero crosses stepping stones that collapse when rushed.
+- Reward intent: introduce the idea that steady runs generate focus.
+
+### Day 5: First Words
+
+Player goal: connect drills to readable English words while staying on familiar
+keys.
+
+- Key focus: short English words using home-row-heavy letters.
+- Prompt style: tiny word groups, never long sentences.
+- Review intent: watch whether word recognition causes sloppy finger movement.
+- RPG framing: the hero reads simple runes in the training hall.
+- Reward intent: first small title-style reward can unlock here later.
+
+### Day 6: Repair The Stance
+
+Player goal: clean up weak keys discovered during the first five days.
+
+- Key focus: dynamically selected weak home-row keys once review logic exists.
+- Prompt style: slow perfect drills, repeated misses, and short recovery prompts.
+- Review intent: turn per-character mistake records into targeted practice.
+- RPG framing: the instructor repairs cracks in the hero's stance.
+- Reward intent: reward patient correction more than speed.
+
+### Day 7: Gatekeeper Trial
+
+Player goal: prove that home-row basics are stable enough to leave the Novice
+Hall.
+
+- Key focus: all first-week home-row skills.
+- Prompt style: warm-up, mixed review, then a short boss prompt.
+- Review intent: check accuracy, mistake clusters, and calm recovery.
+- RPG framing: the gatekeeper tests whether the hero may begin the journey.
+- Reward intent: larger XP payout and the first story gate unlock.
+
 ## Lesson Shape
 
 Early lessons should use a tight progression:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,7 +22,7 @@
 - [x] Build a one-prompt raw-mode typing spike behind a testable state machine.
 - [x] Add safe terminal cleanup for Ctrl+C and interrupted raw-mode sessions.
 - [x] Add a first reward screen with skill XP and a simple level-up message.
-- [ ] Draft the first 7-day training cycle.
+- [x] Draft the first 7-day training cycle.
 
 ## Mid Term
 


### PR DESCRIPTION
## Summary
- Expand the Novice Hall first-week curriculum into day-by-day goals.
- Capture key focus, review intent, RPG framing, and reward intent for days 1-7.
- Mark the first 7-day training cycle TODO as complete.

## Test plan
- npm run format:check

Closes #49

Made with [Cursor](https://cursor.com)