### PR TITLE
Add Novice Hall day two lesson

### DIFF
--- a/lessons/novice-hall-day-2.json
+++ b/lessons/novice-hall-day-2.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "id": "novice-hall-day-2",
+  "title": "Novice Hall: Left And Right Balance",
+  "day": 2,
+  "locale": "en",
+  "focus": ["left hand balance", "right hand balance", "home row rhythm"],
+  "prompts": [
+    {
+      "id": "left-right-balance-1",
+      "text": "asdf jkl;",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "left-right-balance-2",
+      "text": "asdf fdsa jkl; ;lkj",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "left-right-balance-3",
+      "text": "af sj dk fl",
+      "targetKeys": ["a", "f", "s", "j", "d", "k", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftIndex",
+        "leftRing",
+        "rightIndex",
+        "leftMiddle",
+        "rightMiddle",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "left-right-balance-4",
+      "text": "sad lad ask fall",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `novice-hall-day-2.json` focused on left/right hand balance and rhythm.
- Keep prompts English-only with target keys, skill tracks, and finger hints.

## Test plan
- npm run verify
- printf '1\nasdf jkl;\nasdf fdsa jkl; ;lkj\naf sj dk fl\n' | npm run dev -- --lesson lessons/novice-hall-day-2.json --save-dir /tmp/keyquest-day-2

Closes #51

Made with [Cursor](https://cursor.com)