### PR TITLE
Connect themes to ANSI styling

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -41,6 +41,33 @@ describe("runApp", () => {
     expect(output.text()).toContain("Rewards");
   });
 
+  it("styles headings when terminal color is enabled", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      terminalRuntime: {
+        colorMode: "always",
+        colorEnabled: true,
+        theme: "classic",
+        reducedMotion: false,
+        size: {
+          columns: 100,
+          rows: 30,
+          isBelowMinimum: false,
+        },
+      },
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("\u001b[93mStory\u001b[0m");
+  });
+
   it("warns when the terminal is below the recommended size", async () => {
     const output = createMemoryOutput();
     await runApp({

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,8 @@ import {
   renderPracticeRewards,
   renderPracticeSegmentResult,
 } from "./scenes/scenes.js";
+import type { SceneContext } from "./scenes/types.js";
+import { styleText } from "./terminal/ansi.js";
 import type { TerminalRuntime } from "./terminal/runtime.js";
 
 export type RunAppOptions = {
@@ -71,11 +73,12 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   let promptStartedAt = now;
 
   for (const [index, practicePrompt] of practicePrompts.entries()) {
-    const context = {
+    const context: SceneContext = {
       save: menuSave,
       mode: options.mode,
       now,
       translator,
+      terminalRuntime: options.terminalRuntime,
       lesson,
       practicePrompt,
     };
@@ -232,9 +235,13 @@ function renderTerminalWarnings(
   }
 
   return [
-    translator.t("terminal.sizeWarning", {
-      columns: terminalRuntime.size.columns ?? "?",
-      rows: terminalRuntime.size.rows ?? "?",
-    }),
+    styleText(
+      translator.t("terminal.sizeWarning", {
+        columns: terminalRuntime.size.columns ?? "?",
+        rows: terminalRuntime.size.rows ?? "?",
+      }),
+      "warning",
+      terminalRuntime,
+    ),
   ];
 }

--- a/src/scenes/manager.test.ts
+++ b/src/scenes/manager.test.ts
@@ -16,6 +16,7 @@ describe("scene manager", () => {
         mode: "normal",
         now,
         translator: createTranslator("en"),
+        terminalRuntime: undefined,
         lesson: {
           schemaVersion: 1,
           id: "novice-hall-day-1",

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -6,6 +6,7 @@ import type {
   SceneContext,
   SceneOutput,
 } from "./types.js";
+import { styleText } from "../terminal/ansi.js";
 
 export const titleScene: Scene = {
   id: "title",
@@ -15,9 +16,11 @@ export const titleScene: Scene = {
     return {
       id: "title",
       lines: [
-        t("app.title"),
+        styleText(t("app.title"), "accent", context.terminalRuntime),
         t("app.subtitle"),
-        context.mode === "development" ? t("dev.banner") : "",
+        context.mode === "development"
+          ? styleText(t("dev.banner"), "warning", context.terminalRuntime)
+          : "",
       ].filter((line) => line.length > 0),
       next: "story",
     };
@@ -32,7 +35,7 @@ export const storyScene: Scene = {
     return {
       id: "story",
       lines: [
-        t("story.heading"),
+        styleText(t("story.heading"), "accent", context.terminalRuntime),
         `Day ${context.lesson.day}: ${context.lesson.title}`,
         t("story.noviceIntro"),
         t("story.noviceQuote"),
@@ -54,7 +57,7 @@ export const statusScene: Scene = {
     return {
       id: "status",
       lines: [
-        t("status.heading"),
+        styleText(t("status.heading"), "accent", context.terminalRuntime),
         t("status.hero", { hero: context.save.profile.heroName }),
         t("status.xp", { xp: context.save.progress.totalXp }),
         t("status.streak", { days: context.save.progress.streakDays }),
@@ -74,7 +77,7 @@ export const practiceIntroScene: Scene = {
     return {
       id: "practiceIntro",
       lines: [
-        t("practice.heading"),
+        styleText(t("practice.heading"), "accent", context.terminalRuntime),
         t("practice.lesson", { lesson: context.lesson.title }),
         t("practice.homeHint"),
         t("practice.keys", { keys: practicePrompt.targetKeys.join(" ") }),

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -3,6 +3,7 @@ import type { Translator } from "../i18n/messages.js";
 import type { Lesson } from "../lessons/schema.js";
 import type { PracticePrompt } from "../practice/session.js";
 import type { KeyQuestSave, SaveMode } from "../save/model.js";
+import type { TerminalRuntime } from "../terminal/runtime.js";
 
 export type SceneId = "title" | "story" | "status" | "practiceIntro" | "exit";
 
@@ -11,6 +12,7 @@ export type SceneContext = {
   readonly mode: SaveMode;
   readonly now: Date;
   readonly translator: Translator;
+  readonly terminalRuntime: TerminalRuntime | undefined;
   readonly lesson: Lesson;
   readonly practicePrompt: PracticePrompt;
 };

--- a/src/terminal/ansi.test.ts
+++ b/src/terminal/ansi.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { styleText } from "./ansi.js";
+import type { TerminalRuntime } from "./runtime.js";
+
+describe("ANSI styling", () => {
+  it("wraps text when color is enabled", () => {
+    expect(styleText("KeyQuest", "accent", createRuntime(true))).toBe(
+      "\u001b[93mKeyQuest\u001b[0m",
+    );
+  });
+
+  it("returns plain text when color is disabled or default", () => {
+    expect(styleText("KeyQuest", "accent", createRuntime(false))).toBe("KeyQuest");
+    expect(styleText("KeyQuest", "accent", undefined)).toBe("KeyQuest");
+  });
+});
+
+function createRuntime(colorEnabled: boolean): TerminalRuntime {
+  return {
+    colorMode: colorEnabled ? "always" : "never",
+    colorEnabled,
+    theme: "classic",
+    reducedMotion: false,
+    size: {
+      columns: 100,
+      rows: 30,
+      isBelowMinimum: false,
+    },
+  };
+}

--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -1,0 +1,43 @@
+import type { TerminalRuntime } from "./runtime.js";
+import { resolveTerminalTheme, type TerminalColorName, type TerminalColorToken } from "./theme.js";
+
+const RESET = "\u001b[0m";
+
+const ANSI_CODES: Readonly<Record<TerminalColorName, number | undefined>> = {
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37,
+  brightBlack: 90,
+  brightRed: 91,
+  brightGreen: 92,
+  brightYellow: 93,
+  brightBlue: 94,
+  brightMagenta: 95,
+  brightCyan: 96,
+  brightWhite: 97,
+  default: undefined,
+};
+
+export function styleText(
+  text: string,
+  token: TerminalColorToken,
+  runtime: TerminalRuntime | undefined,
+): string {
+  if (runtime?.colorEnabled !== true) {
+    return text;
+  }
+
+  const theme = resolveTerminalTheme(runtime.theme);
+  const colorName = theme.colors[token];
+  const code = ANSI_CODES[colorName];
+  if (code === undefined) {
+    return text;
+  }
+
+  return `\u001b[${code}m${text}${RESET}`;
+}


### PR DESCRIPTION
## Summary
- Add an ANSI styling helper that maps semantic theme tokens to terminal color codes.
- Style selected scene headings and size warnings through the terminal runtime.
- Preserve plain output when color is disabled or unavailable.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --color always --save-dir /tmp/keyquest-ansi-theme
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --no-color --save-dir /tmp/keyquest-no-color-theme

Closes #54

Made with [Cursor](https://cursor.com)