### PR TITLE
Resolve default lessons by journey day

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import type { TextInput } from "./cli/text-input.js";
 import type { TextOutput } from "./cli/text-output.js";
 import { createTranslator, localeDisplayName } from "./i18n/messages.js";
 import {
-  DEFAULT_LESSON_PATH,
+  getDefaultLessonPathForDay,
   loadLessonFromFile,
   selectPracticePrompts,
 } from "./lessons/loader.js";
@@ -65,8 +65,9 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     textOutput: options.textOutput,
     writeSave: saveStore.write,
   });
+  const defaultLessonPath = getDefaultLessonPathForDay(menuSave.journey.day);
   const lesson =
-    options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? DEFAULT_LESSON_PATH));
+    options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? defaultLessonPath));
   const practicePrompts = selectPracticePrompts(lesson, DAILY_SESSION_PROMPT_COUNT);
   const translator = createTranslator(menuSave.settings.locale);
   const attempts: PracticeAttempt[] = [];

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { loadLessonFromFile, selectPracticePrompt, selectPracticePrompts } from "./loader.js";
+import {
+  DEFAULT_LESSON_PATH,
+  getDefaultLessonPathForDay,
+  loadLessonFromFile,
+  selectPracticePrompt,
+  selectPracticePrompts,
+} from "./loader.js";
 
 const tempDirectories: string[] = [];
 
@@ -47,6 +53,13 @@ describe("lesson loader", () => {
       fingerHints: ["leftIndex", "rightIndex"],
     });
     expect(selectPracticePrompts(lesson, 3)).toHaveLength(1);
+  });
+
+  it("resolves default lesson paths from journey days", () => {
+    expect(DEFAULT_LESSON_PATH).toBe(getDefaultLessonPathForDay(1));
+    expect(getDefaultLessonPathForDay(2)).toMatch(/lessons\/novice-hall-day-2\.json$/);
+    expect(getDefaultLessonPathForDay(3)).toMatch(/lessons\/novice-hall-day-3\.json$/);
+    expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
   });
 });
 

--- a/src/lessons/loader.ts
+++ b/src/lessons/loader.ts
@@ -4,7 +4,16 @@ import { join } from "node:path";
 import type { PracticePrompt } from "../practice/session.js";
 import { validateLesson, type Lesson, type LessonPrompt } from "./schema.js";
 
-export const DEFAULT_LESSON_PATH = join(process.cwd(), "lessons", "novice-hall-day-1.json");
+export const DEFAULT_LESSON_DIRECTORY = join(process.cwd(), "lessons");
+export const DEFAULT_LESSON_PATH = getDefaultLessonPathForDay(1);
+
+export function getDefaultLessonPathForDay(day: number): string {
+  if (!Number.isInteger(day) || day < 1) {
+    throw new Error(`Lesson day must be a positive integer: ${day}`);
+  }
+
+  return join(DEFAULT_LESSON_DIRECTORY, `novice-hall-day-${day}.json`);
+}
 
 export async function loadLessonFromFile(path: string): Promise<Lesson> {
   const content = await readFile(path, "utf8");


### PR DESCRIPTION
## Summary
- Add `getDefaultLessonPathForDay()` for `lessons/novice-hall-day-N.json` resolution.
- Use the saved journey day when no explicit `--lesson` path is provided.
- Preserve explicit lesson path overrides.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --save-dir /tmp/keyquest-default-day-1

Closes #56

Made with [Cursor](https://cursor.com)