### PR TITLE
Add Novice Hall day four lesson

### DIFF
--- a/lessons/novice-hall-day-4.json
+++ b/lessons/novice-hall-day-4.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "id": "novice-hall-day-4",
+  "title": "Novice Hall: Rhythm Hall",
+  "day": 4,
+  "locale": "en",
+  "focus": ["home row rhythm", "spacing", "steady cadence"],
+  "prompts": [
+    {
+      "id": "rhythm-hall-1",
+      "text": "asdf asdf jkl; jkl;",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "rhythm-hall-2",
+      "text": "fdsa fdsa ;lkj ;lkj",
+      "targetKeys": ["f", "d", "s", "a", ";", "l", "k", "j"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "leftMiddle",
+        "leftRing",
+        "leftPinky",
+        "rightPinky",
+        "rightRing",
+        "rightMiddle",
+        "rightIndex"
+      ]
+    },
+    {
+      "id": "rhythm-hall-3",
+      "text": "asdf fdsa jkl; ;lkj",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "rhythm-hall-4",
+      "text": "ask fall sad flask",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `novice-hall-day-4.json` focused on rhythm and repeated home-row combinations.
- Keep prompts English-only with target keys, skill tracks, and finger hints.

## Test plan
- npm run verify
- printf '1\nasdf asdf jkl; jkl;\nfdsa fdsa ;lkj ;lkj\nasdf fdsa jkl; ;lkj\n' | npm run dev -- --lesson lessons/novice-hall-day-4.json --save-dir /tmp/keyquest-day-4

Closes #58

Made with [Cursor](https://cursor.com)