### PR TITLE
Advance journey day after sessions

### DIFF
--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createNewSave } from "../save/model.js";
 import {
+  advanceJourneyDay,
   calculatePracticeXp,
   collectCharacterMistakes,
   completePracticeRun,
@@ -32,6 +33,7 @@ describe("completePracticeSession", () => {
     expect(result.updatedSave.progress.sessions).toHaveLength(1);
     expect(result.updatedSave.progress.totalXp).toBe(result.xpGained);
     expect(result.updatedSave.journey.storyFlag).toBe("noviceHallStarted");
+    expect(result.updatedSave.journey.day).toBe(2);
     expect(result.updatedSave.progress.sessions[0]?.mistakes).toEqual([]);
   });
 
@@ -150,6 +152,14 @@ describe("completePracticeRun", () => {
         actual: null,
       },
     ]);
+  });
+});
+
+describe("advanceJourneyDay", () => {
+  it("advances through bundled lessons and caps at the latest available day", () => {
+    expect(advanceJourneyDay(1)).toBe(2);
+    expect(advanceJourneyDay(3)).toBe(4);
+    expect(advanceJourneyDay(4)).toBe(4);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -8,6 +8,8 @@ import type {
 } from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
 
+export const LATEST_BUNDLED_JOURNEY_DAY = 4;
+
 export type PracticePrompt = {
   readonly id: string;
   readonly text: string;
@@ -201,6 +203,7 @@ function applyPracticeResult(options: {
     },
     journey: {
       ...options.save.journey,
+      day: advanceJourneyDay(options.save.journey.day),
       storyFlag: "noviceHallStarted",
     },
     progress: {
@@ -240,6 +243,10 @@ function aggregateScores(scores: readonly Score[]): Score {
     wordsPerMinute,
     elapsedSeconds,
   };
+}
+
+export function advanceJourneyDay(currentDay: number): number {
+  return Math.min(currentDay + 1, LATEST_BUNDLED_JOURNEY_DAY);
 }
 
 function uniqueSkillIds(skillIds: readonly SkillTrack["id"][]): readonly SkillTrack["id"][] {


### PR DESCRIPTION
## Summary
- Advance `journey.day` after completed practice sessions.
- Cap progression at the latest bundled lesson day for now.
- Add tests for advancement and cap behavior.

## Test plan
- npm run verify
- Ran two consecutive dev sessions against the same save directory and verified the second run loaded Day 2 automatically.

Closes #60

Made with [Cursor](https://cursor.com)