### PR TITLE
Add Novice Hall day five lesson

### DIFF
--- a/lessons/novice-hall-day-5.json
+++ b/lessons/novice-hall-day-5.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "novice-hall-day-5",
+  "title": "Novice Hall: First Words",
+  "day": 5,
+  "locale": "en",
+  "focus": ["short words", "home row posture", "word accuracy"],
+  "prompts": [
+    {
+      "id": "first-words-1",
+      "text": "ask sad lad",
+      "targetKeys": ["a", "s", "d", "l", "k"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftPinky", "leftRing", "leftMiddle", "rightRing", "rightMiddle"]
+    },
+    {
+      "id": "first-words-2",
+      "text": "fall flask",
+      "targetKeys": ["f", "a", "l", "s", "k"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftIndex", "leftPinky", "rightRing", "leftRing", "rightMiddle"]
+    },
+    {
+      "id": "first-words-3",
+      "text": "dad fad salad",
+      "targetKeys": ["d", "a", "f", "s", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["leftMiddle", "leftPinky", "leftIndex", "leftRing", "rightRing"]
+    },
+    {
+      "id": "first-words-4",
+      "text": "ask lad fall flask",
+      "targetKeys": ["a", "s", "k", "l", "d", "f"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "rightMiddle",
+        "rightRing",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    }
+  ]
+}

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -59,6 +59,7 @@ describe("lesson loader", () => {
     expect(DEFAULT_LESSON_PATH).toBe(getDefaultLessonPathForDay(1));
     expect(getDefaultLessonPathForDay(2)).toMatch(/lessons\/novice-hall-day-2\.json$/);
     expect(getDefaultLessonPathForDay(3)).toMatch(/lessons\/novice-hall-day-3\.json$/);
+    expect(getDefaultLessonPathForDay(5)).toMatch(/lessons\/novice-hall-day-5\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -159,7 +159,8 @@ describe("advanceJourneyDay", () => {
   it("advances through bundled lessons and caps at the latest available day", () => {
     expect(advanceJourneyDay(1)).toBe(2);
     expect(advanceJourneyDay(3)).toBe(4);
-    expect(advanceJourneyDay(4)).toBe(4);
+    expect(advanceJourneyDay(4)).toBe(5);
+    expect(advanceJourneyDay(5)).toBe(5);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -8,7 +8,7 @@ import type {
 } from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
 
-export const LATEST_BUNDLED_JOURNEY_DAY = 4;
+export const LATEST_BUNDLED_JOURNEY_DAY = 5;
 
 export type PracticePrompt = {
   readonly id: string;


### PR DESCRIPTION
## Summary
- Add `novice-hall-day-5.json` focused on short English words using familiar keys.
- Extend bundled journey advancement and path tests through Day 5.

## Test plan
- npm run verify
- printf '1\nask sad lad\nfall flask\ndad fad salad\n' | npm run dev -- --lesson lessons/novice-hall-day-5.json --save-dir /tmp/keyquest-day-5

Closes #62

Made with [Cursor](https://cursor.com)