### PR TITLE
Add Novice Hall day six lesson

### DIFF
--- a/lessons/novice-hall-day-6.json
+++ b/lessons/novice-hall-day-6.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "novice-hall-day-6",
+  "title": "Novice Hall: Repair The Stance",
+  "day": 6,
+  "locale": "en",
+  "focus": ["weak finger repair", "slow perfect typing", "home row recovery"],
+  "prompts": [
+    {
+      "id": "repair-stance-1",
+      "text": "aa ;; ss ll",
+      "targetKeys": ["a", ";", "s", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftPinky", "rightPinky", "leftRing", "rightRing"]
+    },
+    {
+      "id": "repair-stance-2",
+      "text": "a; s; al sl",
+      "targetKeys": ["a", ";", "s", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftPinky", "rightPinky", "leftRing", "rightRing"]
+    },
+    {
+      "id": "repair-stance-3",
+      "text": "sad lass fall",
+      "targetKeys": ["s", "a", "d", "l", "f"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftRing", "leftPinky", "leftMiddle", "rightRing", "leftIndex"]
+    },
+    {
+      "id": "repair-stance-4",
+      "text": "ask lass fall salad",
+      "targetKeys": ["a", "s", "k", "l", "f", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "rightMiddle",
+        "rightRing",
+        "leftIndex",
+        "leftMiddle"
+      ]
+    }
+  ]
+}

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -60,6 +60,7 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(2)).toMatch(/lessons\/novice-hall-day-2\.json$/);
     expect(getDefaultLessonPathForDay(3)).toMatch(/lessons\/novice-hall-day-3\.json$/);
     expect(getDefaultLessonPathForDay(5)).toMatch(/lessons\/novice-hall-day-5\.json$/);
+    expect(getDefaultLessonPathForDay(6)).toMatch(/lessons\/novice-hall-day-6\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -160,7 +160,8 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(1)).toBe(2);
     expect(advanceJourneyDay(3)).toBe(4);
     expect(advanceJourneyDay(4)).toBe(5);
-    expect(advanceJourneyDay(5)).toBe(5);
+    expect(advanceJourneyDay(5)).toBe(6);
+    expect(advanceJourneyDay(6)).toBe(6);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -8,7 +8,7 @@ import type {
 } from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
 
-export const LATEST_BUNDLED_JOURNEY_DAY = 5;
+export const LATEST_BUNDLED_JOURNEY_DAY = 6;
 
 export type PracticePrompt = {
   readonly id: string;


### PR DESCRIPTION
## Summary
- Add `novice-hall-day-6.json` focused on weak-finger repair and slow perfect home-row typing.
- Extend bundled journey advancement and path tests through Day 6.

## Test plan
- npm run verify
- printf '1\naa ;; ss ll\na; s; al sl\nsad lass fall\n' | npm run dev -- --lesson lessons/novice-hall-day-6.json --save-dir /tmp/keyquest-day-6

Closes #66

Made with [Cursor](https://cursor.com)