### PR TITLE
Add Novice Hall day seven lesson

### DIFF
--- a/lessons/novice-hall-day-7.json
+++ b/lessons/novice-hall-day-7.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "id": "novice-hall-day-7",
+  "title": "Novice Hall: Gatekeeper Trial",
+  "day": 7,
+  "locale": "en",
+  "focus": ["home row trial", "accuracy check", "calm recovery"],
+  "prompts": [
+    {
+      "id": "gatekeeper-trial-1",
+      "text": "f j as df jk l;",
+      "targetKeys": ["f", "j", "a", "s", "d", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "rightIndex",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "gatekeeper-trial-2",
+      "text": "asdf fdsa jkl; ;lkj",
+      "targetKeys": ["a", "s", "d", "f", "j", "k", "l", ";"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "gatekeeper-trial-3",
+      "text": "ask sad lad fall",
+      "targetKeys": ["a", "s", "k", "d", "l", "f"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "rightMiddle",
+        "leftMiddle",
+        "rightRing",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "gatekeeper-trial-4",
+      "text": "ask lass fall salad flask",
+      "targetKeys": ["a", "s", "k", "l", "f", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "rightMiddle",
+        "rightRing",
+        "leftIndex",
+        "leftMiddle"
+      ]
+    }
+  ]
+}

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -61,6 +61,7 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(3)).toMatch(/lessons\/novice-hall-day-3\.json$/);
     expect(getDefaultLessonPathForDay(5)).toMatch(/lessons\/novice-hall-day-5\.json$/);
     expect(getDefaultLessonPathForDay(6)).toMatch(/lessons\/novice-hall-day-6\.json$/);
+    expect(getDefaultLessonPathForDay(7)).toMatch(/lessons\/novice-hall-day-7\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -161,7 +161,8 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(3)).toBe(4);
     expect(advanceJourneyDay(4)).toBe(5);
     expect(advanceJourneyDay(5)).toBe(6);
-    expect(advanceJourneyDay(6)).toBe(6);
+    expect(advanceJourneyDay(6)).toBe(7);
+    expect(advanceJourneyDay(7)).toBe(7);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -8,7 +8,7 @@ import type {
 } from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
 
-export const LATEST_BUNDLED_JOURNEY_DAY = 6;
+export const LATEST_BUNDLED_JOURNEY_DAY = 7;
 
 export type PracticePrompt = {
   readonly id: string;


### PR DESCRIPTION
## Summary
- Add `novice-hall-day-7.json` for the first-week Gatekeeper Trial.
- Extend bundled journey advancement and path tests through Day 7.

## Test plan
- npm run verify
- printf '1\nf j as df jk l;\nasdf fdsa jkl; ;lkj\nask sad lad fall\n' | npm run dev -- --lesson lessons/novice-hall-day-7.json --save-dir /tmp/keyquest-day-7

Closes #68

Made with [Cursor](https://cursor.com)