### PR TITLE
Add bundled lesson manifest

### DIFF
--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -63,6 +63,7 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(6)).toMatch(/lessons\/novice-hall-day-6\.json$/);
     expect(getDefaultLessonPathForDay(7)).toMatch(/lessons\/novice-hall-day-7\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
+    expect(() => getDefaultLessonPathForDay(8)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/loader.ts
+++ b/src/lessons/loader.ts
@@ -2,17 +2,14 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { PracticePrompt } from "../practice/session.js";
+import { getBundledLessonForDay } from "./manifest.js";
 import { validateLesson, type Lesson, type LessonPrompt } from "./schema.js";
 
 export const DEFAULT_LESSON_DIRECTORY = join(process.cwd(), "lessons");
 export const DEFAULT_LESSON_PATH = getDefaultLessonPathForDay(1);
 
 export function getDefaultLessonPathForDay(day: number): string {
-  if (!Number.isInteger(day) || day < 1) {
-    throw new Error(`Lesson day must be a positive integer: ${day}`);
-  }
-
-  return join(DEFAULT_LESSON_DIRECTORY, `novice-hall-day-${day}.json`);
+  return join(DEFAULT_LESSON_DIRECTORY, getBundledLessonForDay(day).filename);
 }
 
 export async function loadLessonFromFile(path: string): Promise<Lesson> {

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUNDLED_LESSON_MANIFEST,
+  getBundledLessonForDay,
+  getLatestBundledLessonDay,
+} from "./manifest.js";
+
+describe("bundled lesson manifest", () => {
+  it("lists bundled lessons in day order", () => {
+    expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(getLatestBundledLessonDay()).toBe(7);
+  });
+
+  it("resolves lessons by day and rejects unavailable days", () => {
+    expect(getBundledLessonForDay(7)).toEqual({
+      day: 7,
+      id: "novice-hall-day-7",
+      filename: "novice-hall-day-7.json",
+      title: "Novice Hall: Gatekeeper Trial",
+    });
+    expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
+    expect(() => getBundledLessonForDay(8)).toThrow("No bundled lesson");
+  });
+});

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -1,0 +1,73 @@
+export type BundledLessonManifestEntry = {
+  readonly day: number;
+  readonly id: string;
+  readonly filename: string;
+  readonly title: string;
+};
+
+export const BUNDLED_LESSON_MANIFEST = [
+  {
+    day: 1,
+    id: "novice-hall-day-1",
+    filename: "novice-hall-day-1.json",
+    title: "Novice Hall: Home Position",
+  },
+  {
+    day: 2,
+    id: "novice-hall-day-2",
+    filename: "novice-hall-day-2.json",
+    title: "Novice Hall: Left And Right Balance",
+  },
+  {
+    day: 3,
+    id: "novice-hall-day-3",
+    filename: "novice-hall-day-3.json",
+    title: "Novice Hall: Finger Responsibility",
+  },
+  {
+    day: 4,
+    id: "novice-hall-day-4",
+    filename: "novice-hall-day-4.json",
+    title: "Novice Hall: Rhythm Hall",
+  },
+  {
+    day: 5,
+    id: "novice-hall-day-5",
+    filename: "novice-hall-day-5.json",
+    title: "Novice Hall: First Words",
+  },
+  {
+    day: 6,
+    id: "novice-hall-day-6",
+    filename: "novice-hall-day-6.json",
+    title: "Novice Hall: Repair The Stance",
+  },
+  {
+    day: 7,
+    id: "novice-hall-day-7",
+    filename: "novice-hall-day-7.json",
+    title: "Novice Hall: Gatekeeper Trial",
+  },
+] as const satisfies readonly BundledLessonManifestEntry[];
+
+export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {
+  if (!Number.isInteger(day) || day < 1) {
+    throw new Error(`Lesson day must be a positive integer: ${day}`);
+  }
+
+  const lesson = BUNDLED_LESSON_MANIFEST.find((entry) => entry.day === day);
+  if (lesson === undefined) {
+    throw new Error(`No bundled lesson is available for day ${day}`);
+  }
+
+  return lesson;
+}
+
+export function getLatestBundledLessonDay(): number {
+  const latestLesson = BUNDLED_LESSON_MANIFEST.at(-1);
+  if (latestLesson === undefined) {
+    throw new Error("Bundled lesson manifest must include at least one lesson");
+  }
+
+  return latestLesson.day;
+}

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -1,4 +1,5 @@
 import { scoreTypingResult, type Score } from "../core/scoring.js";
+import { getLatestBundledLessonDay } from "../lessons/manifest.js";
 import type {
   CharacterMistakeRecord,
   KeyQuestSave,
@@ -7,8 +8,6 @@ import type {
   SkillTrack,
 } from "../save/model.js";
 import type { FingerId } from "../lessons/schema.js";
-
-export const LATEST_BUNDLED_JOURNEY_DAY = 7;
 
 export type PracticePrompt = {
   readonly id: string;
@@ -246,7 +245,7 @@ function aggregateScores(scores: readonly Score[]): Score {
 }
 
 export function advanceJourneyDay(currentDay: number): number {
-  return Math.min(currentDay + 1, LATEST_BUNDLED_JOURNEY_DAY);
+  return Math.min(currentDay + 1, getLatestBundledLessonDay());
 }
 
 function uniqueSkillIds(skillIds: readonly SkillTrack["id"][]): readonly SkillTrack["id"][] {


### PR DESCRIPTION
## Summary
- Add a bundled lesson manifest for Novice Hall days 1-7.
- Resolve default lesson paths through manifest entries.
- Advance journey days using the manifest's latest bundled day.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --save-dir /tmp/keyquest-manifest-default

Closes #70

Made with [Cursor](https://cursor.com)