### PR TITLE
Show journey advancement after rewards

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -8,6 +8,7 @@ import { runApp } from "./app.js";
 import type { TextInput } from "./cli/text-input.js";
 import type { TextOutput } from "./cli/text-output.js";
 import type { Lesson } from "./lessons/schema.js";
+import { createNewSave } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 
 const tempDirectories: string[] = [];
@@ -39,6 +40,34 @@ describe("runApp", () => {
     expect(output.text()).toContain("Time: 20.0s");
     expect(output.text()).toContain("XP gained");
     expect(output.text()).toContain("Rewards");
+    expect(output.text()).toContain("Next lesson: Day 2 is ready for next time.");
+  });
+
+  it("does not show journey advancement when already at the latest bundled day", async () => {
+    const directory = await createTempDirectory();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    await createSaveStore({ mode: "development", directory }).write({
+      ...createNewSave(now, "development"),
+      journey: {
+        day: 7,
+        chapter: 1,
+        storyFlag: "noviceHallStarted",
+      },
+    });
+    const output = createMemoryOutput();
+
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now,
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).not.toContain("Next lesson:");
   });
 
   it("styles headings when terminal color is enabled", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
 import {
   defaultScenes,
   practiceIntroScene,
+  renderPracticeJourneyProgress,
   renderPracticeRunResult,
   renderPracticeRewards,
   renderPracticeSegmentResult,
@@ -154,6 +155,17 @@ export async function runApp(options: RunAppOptions): Promise<void> {
       translator,
     ).join("\n"),
   );
+  const journeyProgressLines = renderPracticeJourneyProgress(
+    {
+      beforeSave: menuSave,
+      afterSave: result.updatedSave,
+    },
+    translator,
+  );
+  if (journeyProgressLines.length > 0) {
+    options.textOutput.writeLine("");
+    options.textOutput.writeLine(journeyProgressLines.join("\n"));
+  }
 }
 
 async function runTitleMenu(options: {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -57,6 +57,8 @@ const EN_MESSAGES = {
   "reward.heading": "Rewards",
   "reward.skillXp": "{skill}: +{xp} XP (Lv.{level})",
   "reward.levelUp": "Level up: {skill} Lv.{level}",
+  "journey.heading": "Journey",
+  "journey.nextDay": "Next lesson: Day {day} is ready for next time.",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -111,6 +113,8 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "reward.heading": "報酬",
     "reward.skillXp": "{skill}: +{xp} XP (Lv.{level})",
     "reward.levelUp": "レベルアップ: {skill} Lv.{level}",
+    "journey.heading": "旅路",
+    "journey.nextDay": "次回は Day {day} のレッスンに進めます。",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createTranslator } from "../i18n/messages.js";
 import { createNewSave } from "../save/model.js";
-import { renderPracticeRewards } from "./scenes.js";
+import { renderPracticeJourneyProgress, renderPracticeRewards } from "./scenes.js";
 
 describe("scene rendering", () => {
   it("renders skill XP and level-up rewards", () => {
@@ -32,5 +32,35 @@ describe("scene rendering", () => {
         createTranslator("en"),
       ),
     ).toEqual(["Rewards", "homePosition: +100 XP (Lv.2)", "Level up: homePosition Lv.2"]);
+  });
+
+  it("renders journey progress only when the day advances", () => {
+    const beforeSave = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+    const afterSave = {
+      ...beforeSave,
+      journey: {
+        ...beforeSave.journey,
+        day: 2,
+      },
+    };
+
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave,
+          afterSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Journey", "Next lesson: Day 2 is ready for next time."]);
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave: afterSave,
+          afterSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual([]);
   });
 });

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,4 +1,5 @@
 import type {
+  PracticeJourneyProgressView,
   PracticeRewardsView,
   PracticeResultView,
   PracticeRunResultView,
@@ -194,6 +195,20 @@ export function renderPracticeRewards(
   });
 
   return [t("reward.heading"), ...rewardLines];
+}
+
+export function renderPracticeJourneyProgress(
+  progress: PracticeJourneyProgressView,
+  translator: SceneContext["translator"],
+): readonly string[] {
+  const beforeDay = progress.beforeSave.journey.day;
+  const afterDay = progress.afterSave.journey.day;
+  if (afterDay <= beforeDay) {
+    return [];
+  }
+
+  const { t } = translator;
+  return [t("journey.heading"), t("journey.nextDay", { day: afterDay })];
 }
 
 function formatElapsedSeconds(elapsedSeconds: number): string {

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -47,3 +47,8 @@ export type PracticeRewardsView = {
   readonly beforeSave: KeyQuestSave;
   readonly afterSave: KeyQuestSave;
 };
+
+export type PracticeJourneyProgressView = {
+  readonly beforeSave: KeyQuestSave;
+  readonly afterSave: KeyQuestSave;
+};


### PR DESCRIPTION
## Summary
- Add localized journey advancement messages.
- Render progress after rewards when the save advances to a later lesson day.
- Suppress the message when already at the latest bundled lesson.

## Test plan
- npm run verify
- printf '1\nf j\nff jj\nfj jf\n' | npm run dev -- --save-dir /tmp/keyquest-advance-message

Closes #72

Made with [Cursor](https://cursor.com)