### PR TITLE
Select Gatekeeper boss prompt

### DIFF
--- a/lessons/novice-hall-day-7.json
+++ b/lessons/novice-hall-day-7.json
@@ -39,21 +39,7 @@
       ]
     },
     {
-      "id": "gatekeeper-trial-3",
-      "text": "ask sad lad fall",
-      "targetKeys": ["a", "s", "k", "d", "l", "f"],
-      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
-      "fingerHints": [
-        "leftPinky",
-        "leftRing",
-        "rightMiddle",
-        "leftMiddle",
-        "rightRing",
-        "leftIndex"
-      ]
-    },
-    {
-      "id": "gatekeeper-trial-4",
+      "id": "gatekeeper-trial-boss",
       "text": "ask lass fall salad flask",
       "targetKeys": ["a", "s", "k", "l", "f", "d"],
       "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { getDefaultLessonPathForDay, loadLessonFromFile, selectPracticePrompts } from "./loader.js";
 import {
   BUNDLED_LESSON_MANIFEST,
   getBundledLessonForDay,
@@ -21,5 +22,25 @@ describe("bundled lesson manifest", () => {
     });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
     expect(() => getBundledLessonForDay(8)).toThrow("No bundled lesson");
+  });
+
+  it("matches bundled lesson files to manifest metadata", async () => {
+    for (const entry of BUNDLED_LESSON_MANIFEST) {
+      const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(entry.day));
+
+      expect(lesson.id).toBe(entry.id);
+      expect(lesson.title).toBe(entry.title);
+      expect(lesson.day).toBe(entry.day);
+    }
+  });
+
+  it("selects the gatekeeper boss prompt in the current Day 7 session", async () => {
+    const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(7));
+
+    expect(selectPracticePrompts(lesson, 3).map((prompt) => prompt.id)).toEqual([
+      "gatekeeper-trial-1",
+      "gatekeeper-trial-2",
+      "gatekeeper-trial-boss",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Move the Day 7 boss prompt into the first three selected prompts.
- Add manifest-backed validation for bundled lesson files.
- Assert the current Day 7 session includes the boss prompt.

## Test plan
- npm run verify
- printf '1\nf j as df jk l;\nasdf fdsa jkl; ;lkj\nask lass fall salad flask\n' | npm run dev -- --lesson lessons/novice-hall-day-7.json --save-dir /tmp/keyquest-day-7-boss

Closes #74

Made with [Cursor](https://cursor.com)