### PR TITLE
Allow lesson session length overrides

### DIFF
--- a/lessons/novice-hall-day-7.json
+++ b/lessons/novice-hall-day-7.json
@@ -5,6 +5,7 @@
   "day": 7,
   "locale": "en",
   "focus": ["home row trial", "accuracy check", "calm recovery"],
+  "sessionPromptCount": 4,
   "prompts": [
     {
       "id": "gatekeeper-trial-1",
@@ -36,6 +37,20 @@
         "rightMiddle",
         "rightRing",
         "rightPinky"
+      ]
+    },
+    {
+      "id": "gatekeeper-trial-3",
+      "text": "ask sad lad fall",
+      "targetKeys": ["a", "s", "k", "d", "l", "f"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "rightMiddle",
+        "leftMiddle",
+        "rightRing",
+        "leftIndex"
       ]
     },
     {

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -70,6 +70,36 @@ describe("runApp", () => {
     expect(output.text()).not.toContain("Next lesson:");
   });
 
+  it("uses lesson session prompt count overrides", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf", "f j"]),
+      textOutput: output,
+      lesson: {
+        ...createTestLesson(),
+        sessionPromptCount: 4,
+        prompts: [
+          ...createTestLesson().prompts,
+          {
+            id: "home-position-4",
+            text: "f j",
+            targetKeys: ["f", "j"],
+            skillIds: ["homePosition"],
+            fingerHints: ["leftIndex", "rightIndex"],
+          },
+        ],
+      },
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Segment 4/4");
+    expect(output.text()).toContain("Prompts: 4");
+  });
+
   it("styles headings when terminal color is enabled", async () => {
     const output = createMemoryOutput();
     await runApp({

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,7 +69,10 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   const defaultLessonPath = getDefaultLessonPathForDay(menuSave.journey.day);
   const lesson =
     options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? defaultLessonPath));
-  const practicePrompts = selectPracticePrompts(lesson, DAILY_SESSION_PROMPT_COUNT);
+  const practicePrompts = selectPracticePrompts(
+    lesson,
+    lesson.sessionPromptCount ?? DAILY_SESSION_PROMPT_COUNT,
+  );
   const translator = createTranslator(menuSave.settings.locale);
   const attempts: PracticeAttempt[] = [];
   let promptStartedAt = now;

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -36,10 +36,16 @@ describe("bundled lesson manifest", () => {
 
   it("selects the gatekeeper boss prompt in the current Day 7 session", async () => {
     const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(7));
+    const sessionPromptCount = lesson.sessionPromptCount;
+    if (sessionPromptCount === undefined) {
+      throw new Error("Day 7 must define a session prompt count");
+    }
 
-    expect(selectPracticePrompts(lesson, 3).map((prompt) => prompt.id)).toEqual([
+    expect(lesson.sessionPromptCount).toBe(4);
+    expect(selectPracticePrompts(lesson, sessionPromptCount).map((prompt) => prompt.id)).toEqual([
       "gatekeeper-trial-1",
       "gatekeeper-trial-2",
+      "gatekeeper-trial-3",
       "gatekeeper-trial-boss",
     ]);
   });

--- a/src/lessons/schema.test.ts
+++ b/src/lessons/schema.test.ts
@@ -26,6 +26,52 @@ describe("validateLesson", () => {
     expect(lesson.prompts[0]?.text).toBe("f j");
   });
 
+  it("accepts a session prompt count override", () => {
+    const lesson = validateLesson({
+      schemaVersion: 1,
+      id: "boss",
+      title: "Boss",
+      day: 7,
+      locale: "en",
+      focus: ["trial"],
+      sessionPromptCount: 4,
+      prompts: [
+        {
+          id: "boss-1",
+          text: "f j",
+          targetKeys: ["f", "j"],
+          skillIds: ["homePosition"],
+          fingerHints: ["leftIndex", "rightIndex"],
+        },
+      ],
+    });
+
+    expect(lesson.sessionPromptCount).toBe(4);
+  });
+
+  it("rejects invalid session prompt count overrides", () => {
+    expect(() =>
+      validateLesson({
+        schemaVersion: 1,
+        id: "bad-count",
+        title: "Bad Count",
+        day: 1,
+        locale: "en",
+        focus: ["bad"],
+        sessionPromptCount: 0,
+        prompts: [
+          {
+            id: "bad-count-1",
+            text: "f j",
+            targetKeys: ["f", "j"],
+            skillIds: ["homePosition"],
+            fingerHints: ["leftIndex", "rightIndex"],
+          },
+        ],
+      }),
+    ).toThrow("sessionPromptCount must be a positive integer");
+  });
+
   it("rejects empty prompt lists", () => {
     expect(() =>
       validateLesson({

--- a/src/lessons/schema.ts
+++ b/src/lessons/schema.ts
@@ -35,6 +35,7 @@ export type Lesson = {
   readonly day: number;
   readonly locale: "en";
   readonly focus: readonly string[];
+  readonly sessionPromptCount?: number;
   readonly prompts: readonly LessonPrompt[];
 };
 
@@ -52,6 +53,8 @@ export function validateLesson(raw: unknown): Lesson {
     throw new Error("Lesson must include at least one prompt");
   }
 
+  const sessionPromptCount = optionalPositiveInteger(value, "sessionPromptCount");
+
   return {
     schemaVersion: LESSON_SCHEMA_VERSION,
     id: requireString(value, "id"),
@@ -59,6 +62,7 @@ export function validateLesson(raw: unknown): Lesson {
     day: requirePositiveInteger(value, "day"),
     locale: requireLiteral(value, "locale", "en"),
     focus: requireStringArray(value, "focus"),
+    ...(sessionPromptCount === undefined ? {} : { sessionPromptCount }),
     prompts,
   };
 }
@@ -121,6 +125,14 @@ function requirePositiveInteger(record: Record<string, unknown>, key: string): n
   }
 
   return value;
+}
+
+function optionalPositiveInteger(record: Record<string, unknown>, key: string): number | undefined {
+  if (record[key] === undefined) {
+    return undefined;
+  }
+
+  return requirePositiveInteger(record, key);
 }
 
 function requireArray(record: Record<string, unknown>, key: string): readonly unknown[] {


### PR DESCRIPTION
## Summary
- Add optional `sessionPromptCount` validation to the lesson schema.
- Use lesson-specific prompt counts in the app while keeping the default at three prompts.
- Configure Day 7 as a four-prompt Gatekeeper Trial with the boss prompt last.

## Test plan
- npm run verify
- printf '1\nf j as df jk l;\nasdf fdsa jkl; ;lkj\nask sad lad fall\nask lass fall salad flask\n' | npm run dev -- --lesson lessons/novice-hall-day-7.json --save-dir /tmp/keyquest-day-7-four

Closes #78

Made with [Cursor](https://cursor.com)