### PR TITLE
Show Gatekeeper Trial clear message

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -68,6 +68,7 @@ describe("runApp", () => {
     });
 
     expect(output.text()).not.toContain("Next lesson:");
+    expect(output.text()).toContain("Gatekeeper Trial cleared");
   });
 
   it("uses lesson session prompt count overrides", async () => {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -59,6 +59,7 @@ const EN_MESSAGES = {
   "reward.levelUp": "Level up: {skill} Lv.{level}",
   "journey.heading": "Journey",
   "journey.nextDay": "Next lesson: Day {day} is ready for next time.",
+  "journey.noviceHallClear": "Gatekeeper Trial cleared. The Novice Hall opens the road ahead.",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -115,6 +116,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "reward.levelUp": "レベルアップ: {skill} Lv.{level}",
     "journey.heading": "旅路",
     "journey.nextDay": "次回は Day {day} のレッスンに進めます。",
+    "journey.noviceHallClear": "Gatekeeper Trial クリア。Novice Hall の先の道が開きました。",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -5,6 +5,8 @@ export type BundledLessonManifestEntry = {
   readonly title: string;
 };
 
+export const NOVICE_HALL_FINAL_DAY = 7;
+
 export const BUNDLED_LESSON_MANIFEST = [
   {
     day: 1,

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -63,4 +63,25 @@ describe("scene rendering", () => {
       ),
     ).toEqual([]);
   });
+
+  it("renders a Novice Hall clear message on the Gatekeeper Trial day", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 7,
+        chapter: 1,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave,
+          afterSave: beforeSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Journey", "Gatekeeper Trial cleared. The Novice Hall opens the road ahead."]);
+  });
 });

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -7,6 +7,7 @@ import type {
   SceneContext,
   SceneOutput,
 } from "./types.js";
+import { NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
 import { styleText } from "../terminal/ansi.js";
 
 export const titleScene: Scene = {
@@ -201,14 +202,19 @@ export function renderPracticeJourneyProgress(
   progress: PracticeJourneyProgressView,
   translator: SceneContext["translator"],
 ): readonly string[] {
+  const { t } = translator;
   const beforeDay = progress.beforeSave.journey.day;
   const afterDay = progress.afterSave.journey.day;
-  if (afterDay <= beforeDay) {
+  const progressLines = [
+    beforeDay === NOVICE_HALL_FINAL_DAY ? t("journey.noviceHallClear") : "",
+    afterDay > beforeDay ? t("journey.nextDay", { day: afterDay }) : "",
+  ].filter((line) => line.length > 0);
+
+  if (progressLines.length === 0) {
     return [];
   }
 
-  const { t } = translator;
-  return [t("journey.heading"), t("journey.nextDay", { day: afterDay })];
+  return [t("journey.heading"), ...progressLines];
 }
 
 function formatElapsedSeconds(elapsedSeconds: number): string {


### PR DESCRIPTION
## Summary
- Add localized Gatekeeper Trial clear copy.
- Render the clear message when a completed session started on the Novice Hall final day.
- Keep next-day messaging independent for future post-Novice-Hall progression.

## Test plan
- npm run verify

Closes #80

Made with [Cursor](https://cursor.com)