### PR TITLE
Add Meadow Road day eight lesson

### DIFF
--- a/lessons/meadow-road-day-8.json
+++ b/lessons/meadow-road-day-8.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-8",
+  "title": "Meadow Road: First Steps Beyond Home",
+  "day": 8,
+  "locale": "en",
+  "focus": ["vertical movement", "nearby top row keys", "return to home"],
+  "prompts": [
+    {
+      "id": "meadow-road-1",
+      "text": "fr ju fr ju",
+      "targetKeys": ["f", "r", "j", "u"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "rightIndex"]
+    },
+    {
+      "id": "meadow-road-2",
+      "text": "de ki de ki",
+      "targetKeys": ["d", "e", "k", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftMiddle", "leftMiddle", "rightMiddle", "rightMiddle"]
+    },
+    {
+      "id": "meadow-road-3",
+      "text": "red kid ride",
+      "targetKeys": ["r", "e", "d", "k", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftIndex", "leftMiddle", "leftMiddle", "rightMiddle"]
+    },
+    {
+      "id": "meadow-road-4",
+      "text": "rude deer ride",
+      "targetKeys": ["r", "u", "d", "e", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["leftIndex", "rightIndex", "leftMiddle", "leftMiddle", "rightMiddle"]
+    }
+  ]
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -43,7 +43,7 @@ describe("runApp", () => {
     expect(output.text()).toContain("Next lesson: Day 2 is ready for next time.");
   });
 
-  it("does not show journey advancement when already at the latest bundled day", async () => {
+  it("shows Gatekeeper clear and Day 8 advancement after Day 7", async () => {
     const directory = await createTempDirectory();
     const now = new Date("2026-01-01T00:00:00.000Z");
     await createSaveStore({ mode: "development", directory }).write({
@@ -67,8 +67,36 @@ describe("runApp", () => {
       completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
-    expect(output.text()).not.toContain("Next lesson:");
     expect(output.text()).toContain("Gatekeeper Trial cleared");
+    expect(output.text()).toContain("Next lesson: Day 8 is ready for next time.");
+  });
+
+  it("does not show journey advancement when already at the latest bundled day", async () => {
+    const directory = await createTempDirectory();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    await createSaveStore({ mode: "development", directory }).write({
+      ...createNewSave(now, "development"),
+      journey: {
+        day: 8,
+        chapter: 2,
+        storyFlag: "noviceHallStarted",
+      },
+    });
+    const output = createMemoryOutput();
+
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now,
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).not.toContain("Next lesson:");
+    expect(output.text()).not.toContain("Gatekeeper Trial cleared");
   });
 
   it("uses lesson session prompt count overrides", async () => {

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -62,8 +62,9 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(5)).toMatch(/lessons\/novice-hall-day-5\.json$/);
     expect(getDefaultLessonPathForDay(6)).toMatch(/lessons\/novice-hall-day-6\.json$/);
     expect(getDefaultLessonPathForDay(7)).toMatch(/lessons\/novice-hall-day-7\.json$/);
+    expect(getDefaultLessonPathForDay(8)).toMatch(/lessons\/meadow-road-day-8\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
-    expect(() => getDefaultLessonPathForDay(8)).toThrow("No bundled lesson");
+    expect(() => getDefaultLessonPathForDay(9)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -9,8 +9,8 @@ import {
 
 describe("bundled lesson manifest", () => {
   it("lists bundled lessons in day order", () => {
-    expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([1, 2, 3, 4, 5, 6, 7]);
-    expect(getLatestBundledLessonDay()).toBe(7);
+    expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(getLatestBundledLessonDay()).toBe(8);
   });
 
   it("resolves lessons by day and rejects unavailable days", () => {
@@ -20,8 +20,14 @@ describe("bundled lesson manifest", () => {
       filename: "novice-hall-day-7.json",
       title: "Novice Hall: Gatekeeper Trial",
     });
+    expect(getBundledLessonForDay(8)).toEqual({
+      day: 8,
+      id: "meadow-road-day-8",
+      filename: "meadow-road-day-8.json",
+      title: "Meadow Road: First Steps Beyond Home",
+    });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
-    expect(() => getBundledLessonForDay(8)).toThrow("No bundled lesson");
+    expect(() => getBundledLessonForDay(9)).toThrow("No bundled lesson");
   });
 
   it("matches bundled lesson files to manifest metadata", async () => {

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -50,6 +50,12 @@ export const BUNDLED_LESSON_MANIFEST = [
     filename: "novice-hall-day-7.json",
     title: "Novice Hall: Gatekeeper Trial",
   },
+  {
+    day: 8,
+    id: "meadow-road-day-8",
+    filename: "meadow-road-day-8.json",
+    title: "Meadow Road: First Steps Beyond Home",
+  },
 ] as const satisfies readonly BundledLessonManifestEntry[];
 
 export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -162,7 +162,8 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(4)).toBe(5);
     expect(advanceJourneyDay(5)).toBe(6);
     expect(advanceJourneyDay(6)).toBe(7);
-    expect(advanceJourneyDay(7)).toBe(7);
+    expect(advanceJourneyDay(7)).toBe(8);
+    expect(advanceJourneyDay(8)).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `meadow-road-day-8.json` as the first post-Novice-Hall lesson.
- Extend the bundled lesson manifest and journey advancement through Day 8.
- Update tests for Day 7 completion leading into Day 8 and latest-day capping.

## Test plan
- npm run verify
- printf '1\nfr ju fr ju\nde ki de ki\nred kid ride\n' | npm run dev -- --lesson lessons/meadow-road-day-8.json --save-dir /tmp/keyquest-day-8

Closes #82

Made with [Cursor](https://cursor.com)