### PR TITLE
Update docs after post-Novice progress

### DIFF
--- a/docs/ACHIEVEMENTS.md
+++ b/docs/ACHIEVEMENTS.md
@@ -10,6 +10,17 @@ practice bonuses. They should never replace skill.
 
 ## Categories
 
+## Implemented First Slice
+
+The first implementation deliberately keeps achievements small:
+
+- First Steps: complete the first session.
+- Flawless Focus: complete a session with no mistakes.
+
+Achievement unlocks are stored in save progress and rendered after the reward
+screen. Future achievements should reuse this path rather than adding separate
+session-end UI.
+
 ### Continuity
 
 - First Quest: complete the first session.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -94,7 +94,8 @@ system too early.
 - First reward screen with XP gain
 - Simple level-up display for skill tracks
 - First item or title reward
-- First achievement unlock path
+- First achievement unlock path (complete for `firstSession` and
+  `perfectSession`)
 - Save data for rewards that can evolve into equipment, magic, and items
 
 Exit criteria:
@@ -108,7 +109,10 @@ Exit criteria:
 Goal: make lessons easy to write, review, and improve.
 
 - Versioned lesson schema
-- Beginner home-row lessons
+- Beginner home-row lessons through the first Novice Hall week
+- First post-Novice-Hall lesson entry
+- Lesson-specific session prompt counts for boss-style lessons
+- Bundled lesson manifest for default progression
 - Programmer symbol lessons
 - Lesson validation command
 - English-only typing prompts separated from localized UI strings

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,6 +12,7 @@
       `New Game`, and `Load Game`.
 - [x] Keep `main` green with `npm run verify`.
 - [x] Add Novice Hall lessons for Day 2 through Day 7.
+- [x] Add the first post-Novice-Hall Day 8 lesson.
 - [x] Resolve the default lesson from the saved journey day.
 - [x] Advance journey day after completed sessions, capped at bundled lessons.
 
@@ -32,10 +33,14 @@
 - [x] Replace the bundled lesson cap with a lesson manifest.
 - [x] Add a small screen message when the journey advances to the next day.
 - [x] Validate bundled lesson files against the lesson manifest.
-- [ ] Design post-Novice-Hall progression after Day 7.
-- [ ] Add a dedicated first-week completion or gatekeeper clear message.
-- [ ] Decide whether boss lessons can override the default three-prompt session
+- [x] Design post-Novice-Hall progression after Day 7.
+- [x] Add a dedicated first-week completion or gatekeeper clear message.
+- [x] Decide whether boss lessons can override the default three-prompt session
       length.
+- [x] Add the first achievement unlock path.
+- [ ] Add achievement definitions for streaks and long-session play.
+- [ ] Add first title reward or item reward after Gatekeeper Trial.
+- [ ] Add a lesson manifest validation command for CI and release checks.
 
 ## Mid Term
 


### PR DESCRIPTION
## Summary
- Mark recent lesson, boss-session, Gatekeeper clear, and achievement work complete.
- Document the first implemented achievement unlocks.
- Add next follow-up tasks for achievement definitions, title/item rewards, and manifest validation.

## Test plan
- npm run verify

Closes #86

Made with [Cursor](https://cursor.com)