### PR TITLE
Add bundled lesson validation command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lessons:validate": "tsx src/lessons/validate-bundled.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "npm run typecheck && npm run lint && npm run format:check && npm run test"
+    "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test"
   },
   "repository": {
     "type": "git",

--- a/src/lessons/validate-bundled.test.ts
+++ b/src/lessons/validate-bundled.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBundledLessons } from "./validate-bundled.js";
+
+describe("bundled lesson validation command", () => {
+  it("validates all bundled lesson files", async () => {
+    await expect(validateBundledLessons()).resolves.toEqual([
+      "1: novice-hall-day-1",
+      "2: novice-hall-day-2",
+      "3: novice-hall-day-3",
+      "4: novice-hall-day-4",
+      "5: novice-hall-day-5",
+      "6: novice-hall-day-6",
+      "7: novice-hall-day-7",
+      "8: meadow-road-day-8",
+    ]);
+  });
+});

--- a/src/lessons/validate-bundled.ts
+++ b/src/lessons/validate-bundled.ts
@@ -1,0 +1,38 @@
+import { getDefaultLessonPathForDay, loadLessonFromFile } from "./loader.js";
+import { BUNDLED_LESSON_MANIFEST } from "./manifest.js";
+
+export async function validateBundledLessons(): Promise<readonly string[]> {
+  const validatedLessons: string[] = [];
+
+  for (const entry of BUNDLED_LESSON_MANIFEST) {
+    const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(entry.day));
+    if (lesson.id !== entry.id) {
+      throw new Error(`Lesson day ${entry.day} id mismatch: ${lesson.id} !== ${entry.id}`);
+    }
+
+    if (lesson.title !== entry.title) {
+      throw new Error(`Lesson day ${entry.day} title mismatch: ${lesson.title} !== ${entry.title}`);
+    }
+
+    if (lesson.day !== entry.day) {
+      throw new Error(`Lesson day mismatch for ${entry.id}: ${lesson.day} !== ${entry.day}`);
+    }
+
+    validatedLessons.push(`${entry.day}: ${entry.id}`);
+  }
+
+  return validatedLessons;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const lessons = await validateBundledLessons();
+    for (const lesson of lessons) {
+      console.log(`validated ${lesson}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Lesson validation failed: ${message}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `validateBundledLessons()` and a `lessons:validate` npm script.
- Validate bundled lesson JSON files against manifest day, id, and title metadata.
- Include lesson validation in `npm run verify`.

## Test plan
- npm run lessons:validate
- npm run verify

Closes #88

Made with [Cursor](https://cursor.com)