### PR TITLE
Add Meadow Road day nine and ten lessons

### DIFF
--- a/lessons/meadow-road-day-10.json
+++ b/lessons/meadow-road-day-10.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-10",
+  "title": "Meadow Road: Index Reach",
+  "day": 10,
+  "locale": "en",
+  "focus": ["index reach", "t and y", "controlled stretch"],
+  "prompts": [
+    {
+      "id": "meadow-road-index-1",
+      "text": "ft jy ft jy",
+      "targetKeys": ["f", "t", "j", "y"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "rightIndex"]
+    },
+    {
+      "id": "meadow-road-index-2",
+      "text": "try yet try yet",
+      "targetKeys": ["t", "r", "y", "e"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "leftMiddle"]
+    },
+    {
+      "id": "meadow-road-index-3",
+      "text": "dry try yard",
+      "targetKeys": ["d", "r", "y", "t", "a"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftMiddle", "leftIndex", "rightIndex", "leftIndex", "leftPinky"]
+    },
+    {
+      "id": "meadow-road-index-4",
+      "text": "stay ready steady",
+      "targetKeys": ["s", "t", "a", "y", "r", "e", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftRing",
+        "leftIndex",
+        "leftPinky",
+        "rightIndex",
+        "leftIndex",
+        "leftMiddle",
+        "leftMiddle"
+      ]
+    }
+  ]
+}

--- a/lessons/meadow-road-day-9.json
+++ b/lessons/meadow-road-day-9.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-9",
+  "title": "Meadow Road: Ring Finger Reach",
+  "day": 9,
+  "locale": "en",
+  "focus": ["ring finger reach", "w and o", "return to home"],
+  "prompts": [
+    {
+      "id": "meadow-road-ring-1",
+      "text": "sw lo sw lo",
+      "targetKeys": ["s", "w", "l", "o"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftRing", "leftRing", "rightRing", "rightRing"]
+    },
+    {
+      "id": "meadow-road-ring-2",
+      "text": "we old we old",
+      "targetKeys": ["w", "e", "o", "l", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["leftRing", "leftMiddle", "rightRing", "rightRing", "leftMiddle"]
+    },
+    {
+      "id": "meadow-road-ring-3",
+      "text": "slow low owl",
+      "targetKeys": ["s", "l", "o", "w"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["leftRing", "rightRing", "rightRing", "leftRing"]
+    },
+    {
+      "id": "meadow-road-ring-4",
+      "text": "old owl slow",
+      "targetKeys": ["o", "l", "d", "w", "s"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": ["rightRing", "rightRing", "leftMiddle", "leftRing", "leftRing"]
+    }
+  ]
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -81,7 +81,7 @@ describe("runApp", () => {
     await createSaveStore({ mode: "development", directory }).write({
       ...createNewSave(now, "development"),
       journey: {
-        day: 8,
+        day: 10,
         chapter: 2,
         storyFlag: "noviceHallStarted",
       },

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -63,8 +63,10 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(6)).toMatch(/lessons\/novice-hall-day-6\.json$/);
     expect(getDefaultLessonPathForDay(7)).toMatch(/lessons\/novice-hall-day-7\.json$/);
     expect(getDefaultLessonPathForDay(8)).toMatch(/lessons\/meadow-road-day-8\.json$/);
+    expect(getDefaultLessonPathForDay(9)).toMatch(/lessons\/meadow-road-day-9\.json$/);
+    expect(getDefaultLessonPathForDay(10)).toMatch(/lessons\/meadow-road-day-10\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
-    expect(() => getDefaultLessonPathForDay(9)).toThrow("No bundled lesson");
+    expect(() => getDefaultLessonPathForDay(11)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -9,8 +9,10 @@ import {
 
 describe("bundled lesson manifest", () => {
   it("lists bundled lessons in day order", () => {
-    expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
-    expect(getLatestBundledLessonDay()).toBe(8);
+    expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+    expect(getLatestBundledLessonDay()).toBe(10);
   });
 
   it("resolves lessons by day and rejects unavailable days", () => {
@@ -26,8 +28,14 @@ describe("bundled lesson manifest", () => {
       filename: "meadow-road-day-8.json",
       title: "Meadow Road: First Steps Beyond Home",
     });
+    expect(getBundledLessonForDay(10)).toEqual({
+      day: 10,
+      id: "meadow-road-day-10",
+      filename: "meadow-road-day-10.json",
+      title: "Meadow Road: Index Reach",
+    });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
-    expect(() => getBundledLessonForDay(9)).toThrow("No bundled lesson");
+    expect(() => getBundledLessonForDay(11)).toThrow("No bundled lesson");
   });
 
   it("matches bundled lesson files to manifest metadata", async () => {

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -56,6 +56,18 @@ export const BUNDLED_LESSON_MANIFEST = [
     filename: "meadow-road-day-8.json",
     title: "Meadow Road: First Steps Beyond Home",
   },
+  {
+    day: 9,
+    id: "meadow-road-day-9",
+    filename: "meadow-road-day-9.json",
+    title: "Meadow Road: Ring Finger Reach",
+  },
+  {
+    day: 10,
+    id: "meadow-road-day-10",
+    filename: "meadow-road-day-10.json",
+    title: "Meadow Road: Index Reach",
+  },
 ] as const satisfies readonly BundledLessonManifestEntry[];
 
 export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {

--- a/src/lessons/validate-bundled.test.ts
+++ b/src/lessons/validate-bundled.test.ts
@@ -13,6 +13,8 @@ describe("bundled lesson validation command", () => {
       "6: novice-hall-day-6",
       "7: novice-hall-day-7",
       "8: meadow-road-day-8",
+      "9: meadow-road-day-9",
+      "10: meadow-road-day-10",
     ]);
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -203,7 +203,9 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(5)).toBe(6);
     expect(advanceJourneyDay(6)).toBe(7);
     expect(advanceJourneyDay(7)).toBe(8);
-    expect(advanceJourneyDay(8)).toBe(8);
+    expect(advanceJourneyDay(8)).toBe(9);
+    expect(advanceJourneyDay(9)).toBe(10);
+    expect(advanceJourneyDay(10)).toBe(10);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Day 9 and Day 10 Meadow Road lessons.
- Extend manifest-backed default lesson resolution through Day 10.
- Update bundled lesson validation and progression tests.

## Test plan
- npm run verify
- printf '1\nsw lo sw lo\nwe old we old\nslow low owl\n' | npm run dev -- --lesson lessons/meadow-road-day-9.json --save-dir /tmp/keyquest-day-9
- printf '1\nft jy ft jy\ntry yet try yet\ndry try yard\n' | npm run dev -- --lesson lessons/meadow-road-day-10.json --save-dir /tmp/keyquest-day-10

Closes #94

Made with [Cursor](https://cursor.com)