### PR TITLE
Track daily streak achievements

### DIFF
--- a/src/achievements/engine.test.ts
+++ b/src/achievements/engine.test.ts
@@ -11,6 +11,7 @@ describe("achievement engine", () => {
       save: createNewSave(now, "normal"),
       session,
       unlockedAt: now,
+      nextStreakDays: 1,
     });
 
     expect(unlocks).toEqual([
@@ -35,6 +36,7 @@ describe("achievement engine", () => {
         },
         session,
         unlockedAt: now,
+        nextStreakDays: 1,
       }),
     ).toEqual([]);
   });
@@ -49,6 +51,7 @@ describe("achievement engine", () => {
           mistakes: [{ promptId: "p1", index: 0, expected: "f", actual: "j" }],
         }),
         unlockedAt: now,
+        nextStreakDays: 1,
       }).map((unlock) => unlock.id),
     ).toEqual(["firstSession"]);
   });
@@ -65,6 +68,7 @@ describe("achievement engine", () => {
           completedAt: "2026-01-01T03:00:00.000Z",
         },
         unlockedAt: now,
+        nextStreakDays: 1,
       }).map((unlock) => unlock.id),
     ).toEqual(["firstSession", "perfectSession", "longWatch", "deepDive", "dungeonMarathon"]);
   });
@@ -80,6 +84,19 @@ describe("achievement engine", () => {
       "deepDive",
       "dungeonMarathon",
     ]);
+  });
+
+  it("unlocks continuity achievements from streak length", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+
+    expect(
+      unlockSessionAchievements({
+        save: createNewSave(now, "normal"),
+        session: createSession({ mistakes: [] }),
+        unlockedAt: now,
+        nextStreakDays: 30,
+      }).map((unlock) => unlock.id),
+    ).toEqual(["firstSession", "perfectSession", "threeDaysPact", "unbrokenSeven", "moonCycle"]);
   });
 });
 

--- a/src/achievements/engine.ts
+++ b/src/achievements/engine.ts
@@ -53,10 +53,14 @@ export function unlockSessionAchievements(options: {
   readonly save: KeyQuestSave;
   readonly session: SessionRecord;
   readonly unlockedAt: Date;
+  readonly nextStreakDays: number;
 }): readonly AchievementRecord[] {
   const candidates: AchievementId[] = [
     options.save.progress.sessions.length === 0 ? "firstSession" : undefined,
     options.session.mistakes.length === 0 ? "perfectSession" : undefined,
+    options.nextStreakDays >= 3 ? "threeDaysPact" : undefined,
+    options.nextStreakDays >= 7 ? "unbrokenSeven" : undefined,
+    options.nextStreakDays >= 30 ? "moonCycle" : undefined,
     sessionElapsedSeconds(options.session) >= LONG_WATCH_SECONDS ? "longWatch" : undefined,
     sessionElapsedSeconds(options.session) >= DEEP_DIVE_SECONDS ? "deepDive" : undefined,
     sessionElapsedSeconds(options.session) >= DUNGEON_MARATHON_SECONDS

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createNewSave } from "../save/model.js";
 import {
   advanceJourneyDay,
+  calculateNextStreakDays,
   calculatePracticeXp,
   collectCharacterMistakes,
   completePracticeRun,
@@ -206,6 +207,38 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(8)).toBe(9);
     expect(advanceJourneyDay(9)).toBe(10);
     expect(advanceJourneyDay(10)).toBe(10);
+  });
+});
+
+describe("calculateNextStreakDays", () => {
+  it("starts, increments, preserves, and resets streaks by UTC date", () => {
+    const firstSave = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+    expect(calculateNextStreakDays(firstSave, new Date("2026-01-01T00:00:10.000Z"))).toBe(1);
+
+    const saveWithSession = {
+      ...firstSave,
+      progress: {
+        ...firstSave.progress,
+        streakDays: 2,
+        sessions: [
+          {
+            id: "session-1",
+            mode: "normal" as const,
+            startedAt: "2026-01-02T00:00:00.000Z",
+            completedAt: "2026-01-02T00:10:00.000Z",
+            promptCount: 1,
+            accuracy: 1,
+            wordsPerMinute: 30,
+            xpGained: 10,
+            mistakes: [],
+          },
+        ],
+      },
+    };
+
+    expect(calculateNextStreakDays(saveWithSession, new Date("2026-01-02T01:00:00.000Z"))).toBe(2);
+    expect(calculateNextStreakDays(saveWithSession, new Date("2026-01-03T00:00:00.000Z"))).toBe(3);
+    expect(calculateNextStreakDays(saveWithSession, new Date("2026-01-05T00:00:00.000Z"))).toBe(1);
   });
 });
 

--- a/src/practice/session.ts
+++ b/src/practice/session.ts
@@ -195,10 +195,12 @@ function applyPracticeResult(options: {
   readonly completedAt: Date;
 }): KeyQuestSave {
   const trainedSkillIds = uniqueSkillIds(options.prompts.flatMap((prompt) => prompt.skillIds));
+  const nextStreakDays = calculateNextStreakDays(options.save, options.completedAt);
   const achievementUnlocks = unlockSessionAchievements({
     save: options.save,
     session: options.session,
     unlockedAt: options.completedAt,
+    nextStreakDays,
   });
   const previousAchievements = options.save.progress.achievements ?? [];
   const titleUnlocks = unlockSessionTitles({
@@ -221,7 +223,7 @@ function applyPracticeResult(options: {
     progress: {
       ...options.save.progress,
       totalXp: options.save.progress.totalXp + options.session.xpGained,
-      streakDays: Math.max(1, options.save.progress.streakDays),
+      streakDays: nextStreakDays,
       sessions: [...options.save.progress.sessions, options.session],
       achievements: [...previousAchievements, ...achievementUnlocks],
       titles: [...previousTitles, ...titleUnlocks],
@@ -261,6 +263,37 @@ function aggregateScores(scores: readonly Score[]): Score {
 
 export function advanceJourneyDay(currentDay: number): number {
   return Math.min(currentDay + 1, getLatestBundledLessonDay());
+}
+
+export function calculateNextStreakDays(save: KeyQuestSave, completedAt: Date): number {
+  const previousSession = save.progress.sessions.at(-1);
+  if (previousSession === undefined) {
+    return 1;
+  }
+
+  const previousDate = toUtcDateKey(new Date(previousSession.completedAt));
+  const currentDate = toUtcDateKey(completedAt);
+  if (currentDate === previousDate) {
+    return Math.max(1, save.progress.streakDays);
+  }
+
+  if (daysBetweenUtcDates(previousDate, currentDate) === 1) {
+    return Math.max(1, save.progress.streakDays) + 1;
+  }
+
+  return 1;
+}
+
+function toUtcDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function daysBetweenUtcDates(fromDate: string, toDate: string): number {
+  const from = Date.parse(`${fromDate}T00:00:00.000Z`);
+  const to = Date.parse(`${toDate}T00:00:00.000Z`);
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+  return Math.round((to - from) / millisecondsPerDay);
 }
 
 function uniqueSkillIds(skillIds: readonly SkillTrack["id"][]): readonly SkillTrack["id"][] {


### PR DESCRIPTION
## Summary
- Replace placeholder streak updates with UTC date-based streak progression.
- Keep same-day sessions from inflating streaks and reset after missed days.
- Unlock 3-day, 7-day, and 30-day continuity achievements from streak length.

## Test plan
- npm run verify

Closes #96

Made with [Cursor](https://cursor.com)