### PR TITLE
Add weak-key review generation

### DIFF
--- a/src/practice/weak-key-review.test.ts
+++ b/src/practice/weak-key-review.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { createNewSave, type CharacterMistakeRecord } from "../save/model.js";
+import { analyzeWeakKeys, createWeakKeyReviewPrompt } from "./weak-key-review.js";
+
+describe("weak-key review", () => {
+  it("ranks expected mistake keys by frequency with stable tie ordering", () => {
+    const save = createSaveWithMistakes([
+      { promptId: "p1", index: 0, expected: "j", actual: "f" },
+      { promptId: "p1", index: 1, expected: "f", actual: "j" },
+      { promptId: "p1", index: 2, expected: "J", actual: "f" },
+      { promptId: "p1", index: 3, expected: "d", actual: "s" },
+      { promptId: "p1", index: 4, expected: null, actual: "x" },
+      { promptId: "p1", index: 5, expected: " ", actual: null },
+    ]);
+
+    expect(analyzeWeakKeys(save)).toEqual([
+      { key: "j", mistakes: 2 },
+      { key: "d", mistakes: 1 },
+      { key: "f", mistakes: 1 },
+    ]);
+  });
+
+  it("creates a deterministic review prompt from weak keys", () => {
+    const save = createSaveWithMistakes([
+      { promptId: "p1", index: 0, expected: "j", actual: "f" },
+      { promptId: "p1", index: 1, expected: "j", actual: "f" },
+      { promptId: "p1", index: 2, expected: "f", actual: "j" },
+      { promptId: "p1", index: 3, expected: "d", actual: "s" },
+      { promptId: "p1", index: 4, expected: "s", actual: "d" },
+      { promptId: "p1", index: 5, expected: "a", actual: "s" },
+    ]);
+
+    expect(createWeakKeyReviewPrompt(save)).toEqual({
+      id: "weak-key-review-j-a-d-f",
+      text: "j j j a a a d d d f f f ja aj ad da df fd fj jf",
+      targetKeys: ["j", "a", "d", "f"],
+      skillIds: ["fingerResponsibility", "accuracy"],
+      fingerHints: ["rightIndex", "leftPinky", "leftMiddle", "leftIndex"],
+    });
+  });
+
+  it("returns no prompt when there are no reviewable mistakes", () => {
+    expect(
+      createWeakKeyReviewPrompt(createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal")),
+    ).toBeUndefined();
+  });
+});
+
+function createSaveWithMistakes(mistakes: readonly CharacterMistakeRecord[]) {
+  const save = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+
+  return {
+    ...save,
+    progress: {
+      ...save.progress,
+      sessions: [
+        {
+          id: "session-1",
+          mode: "normal" as const,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-01T00:10:00.000Z",
+          promptCount: 1,
+          accuracy: 0.5,
+          wordsPerMinute: 20,
+          xpGained: 5,
+          mistakes,
+        },
+      ],
+    },
+  };
+}

--- a/src/practice/weak-key-review.ts
+++ b/src/practice/weak-key-review.ts
@@ -1,0 +1,100 @@
+import type { PracticePrompt } from "./session.js";
+import type { FingerId } from "../lessons/schema.js";
+import type { KeyQuestSave } from "../save/model.js";
+
+export type WeakKeyStat = {
+  readonly key: string;
+  readonly mistakes: number;
+};
+
+const REVIEW_PROMPT_KEY_COUNT = 4;
+const KEY_TO_FINGER: Readonly<Partial<Record<string, FingerId>>> = {
+  q: "leftPinky",
+  a: "leftPinky",
+  z: "leftPinky",
+  w: "leftRing",
+  s: "leftRing",
+  x: "leftRing",
+  e: "leftMiddle",
+  d: "leftMiddle",
+  c: "leftMiddle",
+  r: "leftIndex",
+  t: "leftIndex",
+  f: "leftIndex",
+  g: "leftIndex",
+  v: "leftIndex",
+  b: "leftIndex",
+  y: "rightIndex",
+  u: "rightIndex",
+  h: "rightIndex",
+  j: "rightIndex",
+  n: "rightIndex",
+  m: "rightIndex",
+  i: "rightMiddle",
+  k: "rightMiddle",
+  ",": "rightMiddle",
+  o: "rightRing",
+  l: "rightRing",
+  ".": "rightRing",
+  p: "rightPinky",
+  ";": "rightPinky",
+  "/": "rightPinky",
+};
+
+export function analyzeWeakKeys(save: KeyQuestSave): readonly WeakKeyStat[] {
+  const counts = new Map<string, number>();
+
+  for (const session of save.progress.sessions) {
+    for (const mistake of session.mistakes) {
+      const key = normalizeExpectedKey(mistake.expected);
+      if (key === undefined) {
+        continue;
+      }
+
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([key, mistakes]) => ({ key, mistakes }))
+    .sort((left, right) => right.mistakes - left.mistakes || left.key.localeCompare(right.key));
+}
+
+export function createWeakKeyReviewPrompt(save: KeyQuestSave): PracticePrompt | undefined {
+  const weakKeys = analyzeWeakKeys(save)
+    .filter((stat) => KEY_TO_FINGER[stat.key] !== undefined)
+    .slice(0, REVIEW_PROMPT_KEY_COUNT);
+
+  if (weakKeys.length === 0) {
+    return undefined;
+  }
+
+  const targetKeys = weakKeys.map((stat) => stat.key);
+
+  return {
+    id: `weak-key-review-${targetKeys.join("-")}`,
+    text: buildReviewText(targetKeys),
+    targetKeys,
+    skillIds: ["fingerResponsibility", "accuracy"],
+    fingerHints: targetKeys.map((key) => KEY_TO_FINGER[key] ?? "leftIndex"),
+  };
+}
+
+function normalizeExpectedKey(expected: string | null): string | undefined {
+  if (expected === null || expected.trim().length === 0 || expected.length !== 1) {
+    return undefined;
+  }
+
+  return expected.toLowerCase();
+}
+
+function buildReviewText(targetKeys: readonly string[]): string {
+  const steadyRepeats = targetKeys.flatMap((key) => [key, key, key]);
+  const alternatingPairs = targetKeys.flatMap((key, index) => {
+    const nextKey = targetKeys[(index + 1) % targetKeys.length];
+
+    return nextKey === undefined ? [] : [`${key}${nextKey}`, `${nextKey}${key}`];
+  });
+
+  return [...steadyRepeats, ...alternatingPairs].join(" ");
+}


### PR DESCRIPTION
## Summary
- Add weak-key mistake aggregation from saved session history.
- Generate deterministic review prompts for the most frequent reviewable keys.
- Cover ranking, prompt generation, and empty-history behavior.

## Test plan
- npm run verify

Closes #102

Made with [Cursor](https://cursor.com)