### PR TITLE
Add Meadow Road day eleven through fourteen lessons

### DIFF
--- a/lessons/meadow-road-day-11.json
+++ b/lessons/meadow-road-day-11.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-11",
+  "title": "Meadow Road: Outer Watch",
+  "day": 11,
+  "locale": "en",
+  "focus": ["outer reach", "q and p", "return to home"],
+  "prompts": [
+    {
+      "id": "meadow-road-outer-1",
+      "text": "aq ;p aq ;p",
+      "targetKeys": ["a", "q", ";", "p"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftPinky", "leftPinky", "rightPinky", "rightPinky"]
+    },
+    {
+      "id": "meadow-road-outer-2",
+      "text": "quick quiet",
+      "targetKeys": ["q", "u", "i", "c", "k", "e", "t"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "leftMiddle",
+        "rightMiddle",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "meadow-road-outer-3",
+      "text": "pop pipe pup",
+      "targetKeys": ["p", "o", "i", "e", "u"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["rightPinky", "rightRing", "rightMiddle", "leftMiddle", "rightIndex"]
+    },
+    {
+      "id": "meadow-road-outer-4",
+      "text": "quip quick pop",
+      "targetKeys": ["q", "u", "i", "p", "c", "k", "o"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "rightPinky",
+        "leftMiddle",
+        "rightMiddle",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/lessons/meadow-road-day-12.json
+++ b/lessons/meadow-road-day-12.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-12",
+  "title": "Meadow Road: Top Row Trail",
+  "day": 12,
+  "locale": "en",
+  "focus": ["top row travel", "lateral control", "steady return"],
+  "prompts": [
+    {
+      "id": "meadow-road-trail-1",
+      "text": "qwer uiop qwer uiop",
+      "targetKeys": ["q", "w", "e", "r", "u", "i", "o", "p"],
+      "skillIds": ["homePosition", "fingerResponsibility", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "meadow-road-trail-2",
+      "text": "trew poi poi trew",
+      "targetKeys": ["t", "r", "e", "w", "p", "o", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "leftMiddle",
+        "leftRing",
+        "rightPinky",
+        "rightRing",
+        "rightMiddle"
+      ]
+    },
+    {
+      "id": "meadow-road-trail-3",
+      "text": "we quit we pop",
+      "targetKeys": ["w", "e", "q", "u", "i", "t", "p", "o"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftRing",
+        "leftMiddle",
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightPinky",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "meadow-road-trail-4",
+      "text": "type pure quiet",
+      "targetKeys": ["t", "y", "p", "e", "u", "r", "q", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "rightIndex",
+        "rightPinky",
+        "leftMiddle",
+        "rightIndex",
+        "leftIndex",
+        "leftPinky",
+        "rightMiddle"
+      ]
+    }
+  ]
+}

--- a/lessons/meadow-road-day-13.json
+++ b/lessons/meadow-road-day-13.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-13",
+  "title": "Meadow Road: First Flow",
+  "day": 13,
+  "locale": "en",
+  "focus": ["short word flow", "top row words", "calm rhythm"],
+  "prompts": [
+    {
+      "id": "meadow-road-flow-1",
+      "text": "quiet rider",
+      "targetKeys": ["q", "u", "i", "e", "t", "r", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "leftMiddle"
+      ]
+    },
+    {
+      "id": "meadow-road-flow-2",
+      "text": "type your story",
+      "targetKeys": ["t", "y", "p", "e", "o", "u", "r", "s"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "rightIndex",
+        "rightPinky",
+        "leftMiddle",
+        "rightRing",
+        "rightIndex",
+        "leftIndex",
+        "leftRing"
+      ]
+    },
+    {
+      "id": "meadow-road-flow-3",
+      "text": "we try quiet work",
+      "targetKeys": ["w", "e", "t", "r", "y", "q", "u", "i", "o", "k"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "rightIndex",
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightMiddle"
+      ]
+    },
+    {
+      "id": "meadow-road-flow-4",
+      "text": "steady hands type true",
+      "targetKeys": ["s", "t", "e", "a", "d", "y", "h", "n", "p", "r", "u"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "leftMiddle",
+        "rightIndex",
+        "rightIndex",
+        "rightIndex",
+        "rightPinky",
+        "leftIndex",
+        "rightIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/meadow-road-day-14.json
+++ b/lessons/meadow-road-day-14.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": 1,
+  "id": "meadow-road-day-14",
+  "title": "Meadow Road: Waystone Trial",
+  "day": 14,
+  "locale": "en",
+  "focus": ["weekly checkpoint", "top row control", "accuracy under pressure"],
+  "sessionPromptCount": 4,
+  "prompts": [
+    {
+      "id": "meadow-road-trial-1",
+      "text": "qwer uiop asdf jkl;",
+      "targetKeys": [
+        "q",
+        "w",
+        "e",
+        "r",
+        "u",
+        "i",
+        "o",
+        "p",
+        "a",
+        "s",
+        "d",
+        "f",
+        "j",
+        "k",
+        "l",
+        ";"
+      ],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "meadow-road-trial-2",
+      "text": "quiet type pure work",
+      "targetKeys": ["q", "u", "i", "e", "t", "y", "p", "r", "w", "o", "k"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightPinky",
+        "leftIndex",
+        "leftRing",
+        "rightRing",
+        "rightMiddle"
+      ]
+    },
+    {
+      "id": "meadow-road-trial-3",
+      "text": "steady quiet rider",
+      "targetKeys": ["s", "t", "e", "a", "d", "y", "q", "u", "i", "r"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "leftMiddle",
+        "rightIndex",
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "meadow-road-trial-waystone",
+      "text": "your quiet steady hands type true",
+      "targetKeys": ["y", "o", "u", "r", "q", "i", "e", "t", "s", "a", "d", "h", "n", "p"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
+      "fingerHints": [
+        "rightIndex",
+        "rightRing",
+        "rightIndex",
+        "leftIndex",
+        "leftPinky",
+        "rightMiddle",
+        "leftMiddle",
+        "leftIndex",
+        "leftRing",
+        "leftPinky",
+        "leftMiddle",
+        "rightIndex",
+        "rightIndex",
+        "rightPinky"
+      ]
+    }
+  ]
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -81,7 +81,7 @@ describe("runApp", () => {
     await createSaveStore({ mode: "development", directory }).write({
       ...createNewSave(now, "development"),
       journey: {
-        day: 10,
+        day: 14,
         chapter: 2,
         storyFlag: "noviceHallStarted",
       },

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -65,8 +65,10 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(8)).toMatch(/lessons\/meadow-road-day-8\.json$/);
     expect(getDefaultLessonPathForDay(9)).toMatch(/lessons\/meadow-road-day-9\.json$/);
     expect(getDefaultLessonPathForDay(10)).toMatch(/lessons\/meadow-road-day-10\.json$/);
+    expect(getDefaultLessonPathForDay(11)).toMatch(/lessons\/meadow-road-day-11\.json$/);
+    expect(getDefaultLessonPathForDay(14)).toMatch(/lessons\/meadow-road-day-14\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
-    expect(() => getDefaultLessonPathForDay(11)).toThrow("No bundled lesson");
+    expect(() => getDefaultLessonPathForDay(15)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -10,9 +10,9 @@ import {
 describe("bundled lesson manifest", () => {
   it("lists bundled lessons in day order", () => {
     expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
     ]);
-    expect(getLatestBundledLessonDay()).toBe(10);
+    expect(getLatestBundledLessonDay()).toBe(14);
   });
 
   it("resolves lessons by day and rejects unavailable days", () => {
@@ -34,8 +34,14 @@ describe("bundled lesson manifest", () => {
       filename: "meadow-road-day-10.json",
       title: "Meadow Road: Index Reach",
     });
+    expect(getBundledLessonForDay(14)).toEqual({
+      day: 14,
+      id: "meadow-road-day-14",
+      filename: "meadow-road-day-14.json",
+      title: "Meadow Road: Waystone Trial",
+    });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
-    expect(() => getBundledLessonForDay(11)).toThrow("No bundled lesson");
+    expect(() => getBundledLessonForDay(15)).toThrow("No bundled lesson");
   });
 
   it("matches bundled lesson files to manifest metadata", async () => {
@@ -61,6 +67,22 @@ describe("bundled lesson manifest", () => {
       "gatekeeper-trial-2",
       "gatekeeper-trial-3",
       "gatekeeper-trial-boss",
+    ]);
+  });
+
+  it("selects the Meadow Road checkpoint prompt in the current Day 14 session", async () => {
+    const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(14));
+    const sessionPromptCount = lesson.sessionPromptCount;
+    if (sessionPromptCount === undefined) {
+      throw new Error("Day 14 must define a session prompt count");
+    }
+
+    expect(lesson.sessionPromptCount).toBe(4);
+    expect(selectPracticePrompts(lesson, sessionPromptCount).map((prompt) => prompt.id)).toEqual([
+      "meadow-road-trial-1",
+      "meadow-road-trial-2",
+      "meadow-road-trial-3",
+      "meadow-road-trial-waystone",
     ]);
   });
 });

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -68,6 +68,30 @@ export const BUNDLED_LESSON_MANIFEST = [
     filename: "meadow-road-day-10.json",
     title: "Meadow Road: Index Reach",
   },
+  {
+    day: 11,
+    id: "meadow-road-day-11",
+    filename: "meadow-road-day-11.json",
+    title: "Meadow Road: Outer Watch",
+  },
+  {
+    day: 12,
+    id: "meadow-road-day-12",
+    filename: "meadow-road-day-12.json",
+    title: "Meadow Road: Top Row Trail",
+  },
+  {
+    day: 13,
+    id: "meadow-road-day-13",
+    filename: "meadow-road-day-13.json",
+    title: "Meadow Road: First Flow",
+  },
+  {
+    day: 14,
+    id: "meadow-road-day-14",
+    filename: "meadow-road-day-14.json",
+    title: "Meadow Road: Waystone Trial",
+  },
 ] as const satisfies readonly BundledLessonManifestEntry[];
 
 export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {

--- a/src/lessons/validate-bundled.test.ts
+++ b/src/lessons/validate-bundled.test.ts
@@ -15,6 +15,10 @@ describe("bundled lesson validation command", () => {
       "8: meadow-road-day-8",
       "9: meadow-road-day-9",
       "10: meadow-road-day-10",
+      "11: meadow-road-day-11",
+      "12: meadow-road-day-12",
+      "13: meadow-road-day-13",
+      "14: meadow-road-day-14",
     ]);
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -206,7 +206,9 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(7)).toBe(8);
     expect(advanceJourneyDay(8)).toBe(9);
     expect(advanceJourneyDay(9)).toBe(10);
-    expect(advanceJourneyDay(10)).toBe(10);
+    expect(advanceJourneyDay(10)).toBe(11);
+    expect(advanceJourneyDay(13)).toBe(14);
+    expect(advanceJourneyDay(14)).toBe(14);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Meadow Road Day 11 through Day 14 lessons.
- Make Day 14 a four-prompt Waystone Trial checkpoint.
- Extend manifest-backed lesson resolution and progression through Day 14.

## Test plan
- npm run verify
- printf '1\naq ;p aq ;p\nquick quiet\npop pipe pup\n' | npm run dev -- --lesson lessons/meadow-road-day-11.json --save-dir /tmp/keyquest-day-11
- printf '1\nqwer uiop asdf jkl;\nquiet type pure work\nsteady quiet rider\nyour quiet steady hands type true\n' | npm run dev -- --lesson lessons/meadow-road-day-14.json --save-dir /tmp/keyquest-day-14

Closes #104

Made with [Cursor](https://cursor.com)