### PR TITLE
Add Meadow Road clear reward

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -103,6 +103,34 @@ describe("runApp", () => {
     expect(output.text()).not.toContain("Gatekeeper Trial cleared");
   });
 
+  it("shows Meadow Road clear and second-week title after Day 14", async () => {
+    const directory = await createTempDirectory();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    await createSaveStore({ mode: "development", directory }).write({
+      ...createNewSave(now, "development"),
+      journey: {
+        day: 14,
+        chapter: 2,
+        storyFlag: "noviceHallStarted",
+      },
+    });
+    const output = createMemoryOutput();
+
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now,
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Waystone Trial cleared");
+    expect(output.text()).toContain("Earned title: Meadow Road Pathfinder");
+  });
+
   it("uses lesson session prompt count overrides", async () => {
     const output = createMemoryOutput();
     await runApp({

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -78,9 +78,11 @@ const EN_MESSAGES = {
   "titleReward.heading": "Titles",
   "titleReward.unlocked": "Earned title: {title}",
   "titleReward.noviceHallGraduate": "Novice Hall Graduate",
+  "titleReward.meadowRoadPathfinder": "Meadow Road Pathfinder",
   "journey.heading": "Journey",
   "journey.nextDay": "Next lesson: Day {day} is ready for next time.",
   "journey.noviceHallClear": "Gatekeeper Trial cleared. The Novice Hall opens the road ahead.",
+  "journey.meadowRoadClear": "Waystone Trial cleared. The Meadow Road opens into wider lands.",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -157,9 +159,12 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "titleReward.heading": "称号",
     "titleReward.unlocked": "獲得称号: {title}",
     "titleReward.noviceHallGraduate": "Novice Hall 卒業生",
+    "titleReward.meadowRoadPathfinder": "Meadow Road の開拓者",
     "journey.heading": "旅路",
     "journey.nextDay": "次回は Day {day} のレッスンに進めます。",
     "journey.noviceHallClear": "Gatekeeper Trial クリア。Novice Hall の先の道が開きました。",
+    "journey.meadowRoadClear":
+      "Waystone Trial クリア。Meadow Road はさらに広い土地へ続いています。",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -6,6 +6,7 @@ export type BundledLessonManifestEntry = {
 };
 
 export const NOVICE_HALL_FINAL_DAY = 7;
+export const MEADOW_ROAD_FINAL_DAY = 14;
 
 export const BUNDLED_LESSON_MANIFEST = [
   {

--- a/src/rewards/titles.test.ts
+++ b/src/rewards/titles.test.ts
@@ -43,4 +43,23 @@ describe("title rewards", () => {
       [],
     );
   });
+
+  it("unlocks Meadow Road pathfinder title after Day 14", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const save = {
+      ...createNewSave(now, "normal"),
+      journey: {
+        day: 14,
+        chapter: 2,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(unlockSessionTitles({ save, unlockedAt: now })).toEqual([
+      {
+        id: "meadowRoadPathfinder",
+        unlockedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
 });

--- a/src/rewards/titles.ts
+++ b/src/rewards/titles.ts
@@ -1,4 +1,4 @@
-import { NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
+import { MEADOW_ROAD_FINAL_DAY, NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
 import type { KeyQuestSave, TitleRewardId, TitleRewardRecord } from "../save/model.js";
 
 export type TitleRewardDefinition = {
@@ -11,14 +11,20 @@ export const TITLE_REWARDS: Readonly<Record<TitleRewardId, TitleRewardDefinition
     id: "noviceHallGraduate",
     title: "Novice Hall Graduate",
   },
+  meadowRoadPathfinder: {
+    id: "meadowRoadPathfinder",
+    title: "Meadow Road Pathfinder",
+  },
 };
 
 export function unlockSessionTitles(options: {
   readonly save: KeyQuestSave;
   readonly unlockedAt: Date;
 }): readonly TitleRewardRecord[] {
-  const candidates: TitleRewardId[] =
-    options.save.journey.day === NOVICE_HALL_FINAL_DAY ? ["noviceHallGraduate"] : [];
+  const candidates: TitleRewardId[] = [
+    options.save.journey.day === NOVICE_HALL_FINAL_DAY ? "noviceHallGraduate" : undefined,
+    options.save.journey.day === MEADOW_ROAD_FINAL_DAY ? "meadowRoadPathfinder" : undefined,
+  ].filter((id): id is TitleRewardId => id !== undefined);
   const existingTitleIds = new Set((options.save.progress.titles ?? []).map((title) => title.id));
 
   return candidates

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -32,7 +32,7 @@ export type AchievementRecord = {
   readonly unlockedAt: string;
 };
 
-export type TitleRewardId = "noviceHallGraduate";
+export type TitleRewardId = "noviceHallGraduate" | "meadowRoadPathfinder";
 
 export type TitleRewardRecord = {
   readonly id: TitleRewardId;

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -92,6 +92,27 @@ describe("scene rendering", () => {
     ).toEqual(["Titles", "Earned title: Novice Hall Graduate"]);
   });
 
+  it("renders the Meadow Road clear message on the Waystone Trial day", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 14,
+        chapter: 2,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave,
+          afterSave: beforeSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Journey", "Waystone Trial cleared. The Meadow Road opens into wider lands."]);
+  });
+
   it("renders streak milestone progress", () => {
     const beforeSave = {
       ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -10,7 +10,7 @@ import type {
   SceneContext,
   SceneOutput,
 } from "./types.js";
-import { NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
+import { MEADOW_ROAD_FINAL_DAY, NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
 import { styleText } from "../terminal/ansi.js";
 
 export const titleScene: Scene = {
@@ -283,6 +283,7 @@ export function renderPracticeJourneyProgress(
   const afterDay = progress.afterSave.journey.day;
   const progressLines = [
     beforeDay === NOVICE_HALL_FINAL_DAY ? t("journey.noviceHallClear") : "",
+    beforeDay === MEADOW_ROAD_FINAL_DAY ? t("journey.meadowRoadClear") : "",
     afterDay > beforeDay ? t("journey.nextDay", { day: afterDay }) : "",
   ].filter((line) => line.length > 0);
 


### PR DESCRIPTION
## Summary
- Add a Meadow Road final-day boundary.
- Unlock `meadowRoadPathfinder` after Day 14.
- Render a Waystone Trial clear journey message.

## Test plan
- npm run verify

Closes #109

Made with [Cursor](https://cursor.com)