### PR TITLE
Add River Gate day fifteen through twenty-one lessons

### DIFF
--- a/lessons/river-gate-day-15.json
+++ b/lessons/river-gate-day-15.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-15",
+  "title": "River Gate: Lower Step",
+  "day": 15,
+  "locale": "en",
+  "focus": ["bottom row introduction", "c and m", "return to home"],
+  "prompts": [
+    {
+      "id": "river-gate-lower-1",
+      "text": "dc km dc km",
+      "targetKeys": ["d", "c", "k", "m"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftMiddle", "leftMiddle", "rightMiddle", "rightIndex"]
+    },
+    {
+      "id": "river-gate-lower-2",
+      "text": "come calm come calm",
+      "targetKeys": ["c", "o", "m", "e", "a", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftMiddle",
+        "rightRing",
+        "rightIndex",
+        "leftMiddle",
+        "leftPinky",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-lower-3",
+      "text": "make calm moves",
+      "targetKeys": ["m", "a", "k", "e", "c", "l", "o", "v", "s"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "leftPinky",
+        "rightMiddle",
+        "leftMiddle",
+        "leftMiddle",
+        "rightRing",
+        "rightRing",
+        "leftIndex",
+        "leftRing"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-16.json
+++ b/lessons/river-gate-day-16.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-16",
+  "title": "River Gate: Valley Reach",
+  "day": 16,
+  "locale": "en",
+  "focus": ["bottom row reach", "v and n", "index control"],
+  "prompts": [
+    {
+      "id": "river-gate-valley-1",
+      "text": "fv jn fv jn",
+      "targetKeys": ["f", "v", "j", "n"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "rightIndex"]
+    },
+    {
+      "id": "river-gate-valley-2",
+      "text": "even nine even nine",
+      "targetKeys": ["e", "v", "n", "i"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": ["leftMiddle", "leftIndex", "rightIndex", "rightMiddle"]
+    },
+    {
+      "id": "river-gate-valley-3",
+      "text": "move never vanish",
+      "targetKeys": ["m", "o", "v", "e", "n", "r", "a", "i", "s", "h"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "rightRing",
+        "leftIndex",
+        "leftMiddle",
+        "rightIndex",
+        "leftIndex",
+        "leftPinky",
+        "rightMiddle",
+        "leftRing",
+        "rightIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-17.json
+++ b/lessons/river-gate-day-17.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-17",
+  "title": "River Gate: Bridge Keys",
+  "day": 17,
+  "locale": "en",
+  "focus": ["index bridge", "b and g h", "center control"],
+  "prompts": [
+    {
+      "id": "river-gate-bridge-1",
+      "text": "fg jh fb jn",
+      "targetKeys": ["f", "g", "j", "h", "b", "n"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "rightIndex",
+        "rightIndex",
+        "leftIndex",
+        "rightIndex"
+      ]
+    },
+    {
+      "id": "river-gate-bridge-2",
+      "text": "bring bright bring bright",
+      "targetKeys": ["b", "r", "i", "n", "g", "h", "t"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "rightMiddle",
+        "rightIndex",
+        "leftIndex",
+        "rightIndex",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "river-gate-bridge-3",
+      "text": "begin the bridge",
+      "targetKeys": ["b", "e", "g", "i", "n", "t", "h", "r", "d"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftMiddle",
+        "leftIndex",
+        "rightMiddle",
+        "rightIndex",
+        "leftIndex",
+        "rightIndex",
+        "leftIndex",
+        "leftMiddle"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-18.json
+++ b/lessons/river-gate-day-18.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-18",
+  "title": "River Gate: Comma And Period",
+  "day": 18,
+  "locale": "en",
+  "focus": ["comma", "period", "right-hand punctuation"],
+  "prompts": [
+    {
+      "id": "river-gate-punct-1",
+      "text": "k, l. k, l.",
+      "targetKeys": ["k", ",", "l", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": ["rightMiddle", "rightMiddle", "rightRing", "rightRing"]
+    },
+    {
+      "id": "river-gate-punct-2",
+      "text": "calm, steady.",
+      "targetKeys": ["c", "a", "l", "m", ",", "s", "t", "e", "d", "y", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftMiddle",
+        "leftPinky",
+        "rightRing",
+        "rightIndex",
+        "rightMiddle",
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftMiddle",
+        "rightIndex",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-punct-3",
+      "text": "move, rest. move, rest.",
+      "targetKeys": ["m", "o", "v", "e", ",", "r", "s", "t", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "rightIndex",
+        "rightRing",
+        "leftIndex",
+        "leftMiddle",
+        "rightMiddle",
+        "leftIndex",
+        "leftRing",
+        "leftIndex",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-19.json
+++ b/lessons/river-gate-day-19.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-19",
+  "title": "River Gate: Bottom Row Words",
+  "day": 19,
+  "locale": "en",
+  "focus": ["bottom row words", "mixed rows", "accuracy"],
+  "prompts": [
+    {
+      "id": "river-gate-words-1",
+      "text": "brave move calm",
+      "targetKeys": ["b", "r", "a", "v", "e", "m", "o", "c", "l"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "leftPinky",
+        "leftIndex",
+        "leftMiddle",
+        "rightIndex",
+        "rightRing",
+        "leftMiddle",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-words-2",
+      "text": "never bring panic",
+      "targetKeys": ["n", "e", "v", "r", "b", "i", "g", "p", "a", "c"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "rightIndex",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "leftIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightPinky",
+        "leftPinky",
+        "leftMiddle"
+      ]
+    },
+    {
+      "id": "river-gate-words-3",
+      "text": "steady river, brave hands.",
+      "targetKeys": ["s", "t", "e", "a", "d", "y", "r", "i", "v", ",", "b", "h", "n", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "leftMiddle",
+        "rightIndex",
+        "leftIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightIndex",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-20.json
+++ b/lessons/river-gate-day-20.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-20",
+  "title": "River Gate: Current Review",
+  "day": 20,
+  "locale": "en",
+  "focus": ["mixed-row review", "punctuation review", "steady cadence"],
+  "prompts": [
+    {
+      "id": "river-gate-review-1",
+      "text": "qwer asdf zxcv",
+      "targetKeys": ["q", "w", "e", "r", "a", "s", "d", "f", "z", "x", "c", "v"],
+      "skillIds": ["homePosition", "fingerResponsibility", "rhythm"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "river-gate-review-2",
+      "text": "uiop jkl; nm,.",
+      "targetKeys": ["u", "i", "o", "p", "j", "k", "l", ";", "n", "m", ",", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky",
+        "rightIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-review-3",
+      "text": "bring calm, move steady.",
+      "targetKeys": [
+        "b",
+        "r",
+        "i",
+        "n",
+        "g",
+        "c",
+        "a",
+        "l",
+        "m",
+        ",",
+        "o",
+        "v",
+        "e",
+        "s",
+        "t",
+        "d",
+        "y",
+        "."
+      ],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "rightMiddle",
+        "rightIndex",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "rightRing",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "rightIndex",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/lessons/river-gate-day-21.json
+++ b/lessons/river-gate-day-21.json
@@ -1,0 +1,133 @@
+{
+  "schemaVersion": 1,
+  "id": "river-gate-day-21",
+  "title": "River Gate: Ferryman Trial",
+  "day": 21,
+  "locale": "en",
+  "focus": ["weekly checkpoint", "bottom row control", "punctuation under pressure"],
+  "sessionPromptCount": 4,
+  "prompts": [
+    {
+      "id": "river-gate-trial-1",
+      "text": "asdf qwer zxcv",
+      "targetKeys": ["a", "s", "d", "f", "q", "w", "e", "r", "z", "x", "c", "v"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "river-gate-trial-2",
+      "text": "jkl; uiop nm,.",
+      "targetKeys": ["j", "k", "l", ";", "u", "i", "o", "p", "n", "m", ",", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "rhythm"],
+      "fingerHints": [
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky",
+        "rightIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-trial-3",
+      "text": "never panic, move steady.",
+      "targetKeys": [
+        "n",
+        "e",
+        "v",
+        "r",
+        "p",
+        "a",
+        "i",
+        "c",
+        ",",
+        "m",
+        "o",
+        "s",
+        "t",
+        "d",
+        "y",
+        "."
+      ],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "rightPinky",
+        "leftPinky",
+        "rightMiddle",
+        "leftMiddle",
+        "rightMiddle",
+        "rightIndex",
+        "rightRing",
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "rightIndex",
+        "rightRing"
+      ]
+    },
+    {
+      "id": "river-gate-trial-ferryman",
+      "text": "brave hands cross the quiet river.",
+      "targetKeys": [
+        "b",
+        "r",
+        "a",
+        "v",
+        "e",
+        "h",
+        "n",
+        "d",
+        "s",
+        "c",
+        "o",
+        "t",
+        "q",
+        "u",
+        "i",
+        "."
+      ],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "leftIndex",
+        "leftPinky",
+        "leftIndex",
+        "leftMiddle",
+        "rightIndex",
+        "rightIndex",
+        "leftMiddle",
+        "leftRing",
+        "leftMiddle",
+        "rightRing",
+        "leftIndex",
+        "leftPinky",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -81,7 +81,7 @@ describe("runApp", () => {
     await createSaveStore({ mode: "development", directory }).write({
       ...createNewSave(now, "development"),
       journey: {
-        day: 14,
+        day: 21,
         chapter: 2,
         storyFlag: "noviceHallStarted",
       },
@@ -101,6 +101,7 @@ describe("runApp", () => {
 
     expect(output.text()).not.toContain("Next lesson:");
     expect(output.text()).not.toContain("Gatekeeper Trial cleared");
+    expect(output.text()).not.toContain("Waystone Trial cleared");
   });
 
   it("shows Meadow Road clear and second-week title after Day 14", async () => {

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -67,8 +67,10 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(10)).toMatch(/lessons\/meadow-road-day-10\.json$/);
     expect(getDefaultLessonPathForDay(11)).toMatch(/lessons\/meadow-road-day-11\.json$/);
     expect(getDefaultLessonPathForDay(14)).toMatch(/lessons\/meadow-road-day-14\.json$/);
+    expect(getDefaultLessonPathForDay(15)).toMatch(/lessons\/river-gate-day-15\.json$/);
+    expect(getDefaultLessonPathForDay(21)).toMatch(/lessons\/river-gate-day-21\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
-    expect(() => getDefaultLessonPathForDay(15)).toThrow("No bundled lesson");
+    expect(() => getDefaultLessonPathForDay(22)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -10,9 +10,9 @@ import {
 describe("bundled lesson manifest", () => {
   it("lists bundled lessons in day order", () => {
     expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     ]);
-    expect(getLatestBundledLessonDay()).toBe(14);
+    expect(getLatestBundledLessonDay()).toBe(21);
   });
 
   it("resolves lessons by day and rejects unavailable days", () => {
@@ -40,8 +40,14 @@ describe("bundled lesson manifest", () => {
       filename: "meadow-road-day-14.json",
       title: "Meadow Road: Waystone Trial",
     });
+    expect(getBundledLessonForDay(21)).toEqual({
+      day: 21,
+      id: "river-gate-day-21",
+      filename: "river-gate-day-21.json",
+      title: "River Gate: Ferryman Trial",
+    });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
-    expect(() => getBundledLessonForDay(15)).toThrow("No bundled lesson");
+    expect(() => getBundledLessonForDay(22)).toThrow("No bundled lesson");
   });
 
   it("matches bundled lesson files to manifest metadata", async () => {
@@ -83,6 +89,22 @@ describe("bundled lesson manifest", () => {
       "meadow-road-trial-2",
       "meadow-road-trial-3",
       "meadow-road-trial-waystone",
+    ]);
+  });
+
+  it("selects the River Gate checkpoint prompt in the current Day 21 session", async () => {
+    const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(21));
+    const sessionPromptCount = lesson.sessionPromptCount;
+    if (sessionPromptCount === undefined) {
+      throw new Error("Day 21 must define a session prompt count");
+    }
+
+    expect(lesson.sessionPromptCount).toBe(4);
+    expect(selectPracticePrompts(lesson, sessionPromptCount).map((prompt) => prompt.id)).toEqual([
+      "river-gate-trial-1",
+      "river-gate-trial-2",
+      "river-gate-trial-3",
+      "river-gate-trial-ferryman",
     ]);
   });
 });

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -93,6 +93,48 @@ export const BUNDLED_LESSON_MANIFEST = [
     filename: "meadow-road-day-14.json",
     title: "Meadow Road: Waystone Trial",
   },
+  {
+    day: 15,
+    id: "river-gate-day-15",
+    filename: "river-gate-day-15.json",
+    title: "River Gate: Lower Step",
+  },
+  {
+    day: 16,
+    id: "river-gate-day-16",
+    filename: "river-gate-day-16.json",
+    title: "River Gate: Valley Reach",
+  },
+  {
+    day: 17,
+    id: "river-gate-day-17",
+    filename: "river-gate-day-17.json",
+    title: "River Gate: Bridge Keys",
+  },
+  {
+    day: 18,
+    id: "river-gate-day-18",
+    filename: "river-gate-day-18.json",
+    title: "River Gate: Comma And Period",
+  },
+  {
+    day: 19,
+    id: "river-gate-day-19",
+    filename: "river-gate-day-19.json",
+    title: "River Gate: Bottom Row Words",
+  },
+  {
+    day: 20,
+    id: "river-gate-day-20",
+    filename: "river-gate-day-20.json",
+    title: "River Gate: Current Review",
+  },
+  {
+    day: 21,
+    id: "river-gate-day-21",
+    filename: "river-gate-day-21.json",
+    title: "River Gate: Ferryman Trial",
+  },
 ] as const satisfies readonly BundledLessonManifestEntry[];
 
 export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {

--- a/src/lessons/validate-bundled.test.ts
+++ b/src/lessons/validate-bundled.test.ts
@@ -19,6 +19,13 @@ describe("bundled lesson validation command", () => {
       "12: meadow-road-day-12",
       "13: meadow-road-day-13",
       "14: meadow-road-day-14",
+      "15: river-gate-day-15",
+      "16: river-gate-day-16",
+      "17: river-gate-day-17",
+      "18: river-gate-day-18",
+      "19: river-gate-day-19",
+      "20: river-gate-day-20",
+      "21: river-gate-day-21",
     ]);
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -237,7 +237,9 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(9)).toBe(10);
     expect(advanceJourneyDay(10)).toBe(11);
     expect(advanceJourneyDay(13)).toBe(14);
-    expect(advanceJourneyDay(14)).toBe(14);
+    expect(advanceJourneyDay(14)).toBe(15);
+    expect(advanceJourneyDay(20)).toBe(21);
+    expect(advanceJourneyDay(21)).toBe(21);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add River Gate Day 15 through Day 21 lessons.
- Make Day 21 a four-prompt Ferryman Trial checkpoint.
- Extend manifest-backed lesson resolution and progression through Day 21.

## Test plan
- npm run verify
- printf '1\ndc km dc km\ncome calm come calm\nmake calm moves\n' | npm run dev -- --lesson lessons/river-gate-day-15.json --save-dir /tmp/keyquest-day-15
- printf '1\nasdf qwer zxcv\njkl; uiop nm,.\nnever panic, move steady.\nbrave hands cross the quiet river.\n' | npm run dev -- --lesson lessons/river-gate-day-21.json --save-dir /tmp/keyquest-day-21

Closes #111

Made with [Cursor](https://cursor.com)