### PR TITLE
Add non-scrolling screen renderer

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -215,6 +215,7 @@ describe("runApp", () => {
       terminalRuntime: {
         colorMode: "always",
         colorEnabled: true,
+        screenEnabled: false,
         theme: "classic",
         reducedMotion: false,
         size: {
@@ -230,6 +231,35 @@ describe("runApp", () => {
     expect(output.text()).toContain("\u001b[93mStory\u001b[0m");
   });
 
+  it("redraws major screens when terminal screen rendering is enabled", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      terminalRuntime: {
+        colorMode: "never",
+        colorEnabled: false,
+        screenEnabled: true,
+        theme: "classic",
+        reducedMotion: false,
+        size: {
+          columns: 100,
+          rows: 30,
+          isBelowMinimum: false,
+        },
+      },
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("\u001b[2J\u001b[H");
+    expect(output.text()).toContain("Session Result");
+  });
+
   it("warns when the terminal is below the recommended size", async () => {
     const output = createMemoryOutput();
     await runApp({
@@ -242,6 +272,7 @@ describe("runApp", () => {
       terminalRuntime: {
         colorMode: "auto",
         colorEnabled: true,
+        screenEnabled: false,
         theme: "classic",
         reducedMotion: false,
         size: {
@@ -269,6 +300,7 @@ describe("runApp", () => {
       terminalRuntime: {
         colorMode: "auto",
         colorEnabled: true,
+        screenEnabled: false,
         theme: "classic",
         reducedMotion: false,
         size: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,7 @@ import {
 import type { SceneContext } from "./scenes/types.js";
 import { styleText } from "./terminal/ansi.js";
 import type { TerminalRuntime } from "./terminal/runtime.js";
+import { createScreenRenderer, type ScreenRenderer } from "./terminal/screen.js";
 
 export type RunAppOptions = {
   readonly mode: SaveMode;
@@ -60,6 +61,10 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     ...(options.saveDirectory === undefined ? {} : { directory: options.saveDirectory }),
   });
   const save = await saveStore.loadOrCreate(now);
+  const screen = createScreenRenderer({
+    textOutput: options.textOutput,
+    runtime: options.terminalRuntime,
+  });
   const initialTranslator = createTranslator(save.settings.locale);
   const terminalWarnings = renderTerminalWarnings(options.terminalRuntime, initialTranslator);
   if (terminalWarnings.length > 0) {
@@ -72,7 +77,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     mode: options.mode,
     now,
     textInput: options.textInput,
-    textOutput: options.textOutput,
+    screen,
     writeSave: saveStore.write,
   });
   const menuSave = menuSelection.save;
@@ -112,8 +117,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
       context,
     });
     const introOutput = formatSceneSequence(outputs);
-    options.textOutput.writeLine(introOutput);
-    options.textOutput.writeLine("");
+    screen.render(introOutput);
     const actual = await options.textInput.readLine("> ");
     const completedAt = options.completedAt ?? new Date();
     const attempt = {
@@ -134,8 +138,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
 
     attempts.push(attempt);
     promptStartedAt = completedAt;
-    options.textOutput.writeLine("");
-    options.textOutput.writeLine(
+    screen.render(
       renderPracticeSegmentResult(
         {
           ...segmentResult,
@@ -144,9 +147,8 @@ export async function runApp(options: RunAppOptions): Promise<void> {
           total: practicePrompts.length,
         },
         translator,
-      ).join("\n"),
+      ),
     );
-    options.textOutput.writeLine("");
   }
 
   const result = completePracticeRun({
@@ -158,7 +160,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
 
   await saveStore.write(result.updatedSave);
 
-  options.textOutput.writeLine(
+  const finalScreenSections = [
     renderPracticeRunResult(
       {
         promptCount: result.attempts.length,
@@ -167,18 +169,15 @@ export async function runApp(options: RunAppOptions): Promise<void> {
         mode: options.mode,
       },
       translator,
-    ).join("\n"),
-  );
-  options.textOutput.writeLine("");
-  options.textOutput.writeLine(
+    ),
     renderPracticeRewards(
       {
         beforeSave: menuSave,
         afterSave: result.updatedSave,
       },
       translator,
-    ).join("\n"),
-  );
+    ),
+  ];
   const streakProgressLines = renderPracticeStreakProgress(
     {
       beforeSave: menuSave,
@@ -187,8 +186,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     translator,
   );
   if (streakProgressLines.length > 0) {
-    options.textOutput.writeLine("");
-    options.textOutput.writeLine(streakProgressLines.join("\n"));
+    finalScreenSections.push(streakProgressLines);
   }
   const achievementLines = renderPracticeAchievements(
     {
@@ -198,8 +196,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     translator,
   );
   if (achievementLines.length > 0) {
-    options.textOutput.writeLine("");
-    options.textOutput.writeLine(achievementLines.join("\n"));
+    finalScreenSections.push(achievementLines);
   }
   const titleRewardLines = renderPracticeTitleRewards(
     {
@@ -209,8 +206,7 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     translator,
   );
   if (titleRewardLines.length > 0) {
-    options.textOutput.writeLine("");
-    options.textOutput.writeLine(titleRewardLines.join("\n"));
+    finalScreenSections.push(titleRewardLines);
   }
   const journeyProgressLines = renderPracticeJourneyProgress(
     {
@@ -220,9 +216,9 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     translator,
   );
   if (journeyProgressLines.length > 0) {
-    options.textOutput.writeLine("");
-    options.textOutput.writeLine(journeyProgressLines.join("\n"));
+    finalScreenSections.push(journeyProgressLines);
   }
+  screen.render(joinScreenSections(finalScreenSections));
 }
 
 async function runTitleMenu(options: {
@@ -230,57 +226,56 @@ async function runTitleMenu(options: {
   readonly mode: SaveMode;
   readonly now: Date;
   readonly textInput: TextInput;
-  readonly textOutput: TextOutput;
+  readonly screen: ScreenRenderer;
   readonly writeSave: (save: KeyQuestSave) => Promise<void>;
 }): Promise<{
   readonly save: KeyQuestSave;
   readonly action: Extract<TitleMenuAction, "start" | "review">;
 }> {
   let save = options.save;
+  let notice: string | undefined;
 
   for (;;) {
     const translator = createMenuTranslator(save);
-    options.textOutput.writeLine(renderTitleMenu(save, translator).join("\n"));
-    if (options.mode === "development") {
-      options.textOutput.writeLine(translator.t("dev.banner"));
-    }
+    const titleLines = [
+      ...renderTitleMenu(save, translator),
+      ...(options.mode === "development" ? [translator.t("dev.banner")] : []),
+      ...(notice === undefined ? [] : ["", notice]),
+    ];
+    notice = undefined;
+    options.screen.render(titleLines);
 
     const action = parseTitleMenuAction(
       await options.textInput.readLine(translator.t("title.menu.prompt")),
     );
     if (action === "start") {
-      options.textOutput.writeLine("");
       return { save, action };
     }
 
     if (action === "review") {
       if (createWeakKeyReviewPrompt(save) === undefined) {
-        options.textOutput.writeLine(translator.t("review.noMistakes"));
-        options.textOutput.writeLine("");
+        notice = translator.t("review.noMistakes");
         continue;
       }
 
-      options.textOutput.writeLine("");
       return { save, action };
     }
 
     if (action === "newGame") {
       const newSave = createNewSave(options.now, options.mode);
       await options.writeSave(newSave);
-      options.textOutput.writeLine("");
       return { save: newSave, action: "start" };
     }
 
     if (action === "loadGame") {
-      options.textOutput.writeLine(translator.t("title.menu.loadUnavailable"));
-      options.textOutput.writeLine("");
+      notice = translator.t("title.menu.loadUnavailable");
       continue;
     }
 
     const selectedLocale = await runLanguageOptions({
       save,
       textInput: options.textInput,
-      textOutput: options.textOutput,
+      screen: options.screen,
     });
     save = updateLocale(save, selectedLocale, options.now);
     await options.writeSave(save);
@@ -307,25 +302,25 @@ function createReviewLesson(day: number, title: string, practicePrompt: Practice
   };
 }
 
+function joinScreenSections(sections: readonly (readonly string[])[]): readonly string[] {
+  return sections.flatMap((section, index) => (index === 0 ? section : ["", ...section]));
+}
+
 async function runLanguageOptions(options: {
   readonly save: KeyQuestSave;
   readonly textInput: TextInput;
-  readonly textOutput: TextOutput;
+  readonly screen: ScreenRenderer;
 }): Promise<KeyQuestSave["settings"]["locale"]> {
   const translator = createMenuTranslator(options.save);
-  options.textOutput.writeLine("");
-  options.textOutput.writeLine(
-    renderLanguageOptions(options.save.settings.locale, translator).join("\n"),
-  );
+  options.screen.render(renderLanguageOptions(options.save.settings.locale, translator));
   const selectedLocale = parseLocaleChoice(
     await options.textInput.readLine(translator.t("options.prompt")),
     options.save.settings.locale,
   );
   const nextTranslator = createTranslator(selectedLocale);
-  options.textOutput.writeLine(
+  options.screen.render([
     nextTranslator.t("options.saved", { language: localeDisplayName(selectedLocale) }),
-  );
-  options.textOutput.writeLine("");
+  ]);
 
   return selectedLocale;
 }

--- a/src/terminal/ansi.test.ts
+++ b/src/terminal/ansi.test.ts
@@ -20,6 +20,7 @@ function createRuntime(colorEnabled: boolean): TerminalRuntime {
   return {
     colorMode: colorEnabled ? "always" : "never",
     colorEnabled,
+    screenEnabled: false,
     theme: "classic",
     reducedMotion: false,
     size: {

--- a/src/terminal/runtime.test.ts
+++ b/src/terminal/runtime.test.ts
@@ -64,6 +64,31 @@ describe("terminal runtime", () => {
     ).toBe(true);
   });
 
+  it("enables screen redraws only for TTY output", () => {
+    expect(
+      resolveTerminalRuntime({
+        colorMode: undefined,
+        theme: undefined,
+        reducedMotion: false,
+        columns: 100,
+        rows: 30,
+        isTty: true,
+        env: {},
+      }).screenEnabled,
+    ).toBe(true);
+    expect(
+      resolveTerminalRuntime({
+        colorMode: undefined,
+        theme: undefined,
+        reducedMotion: false,
+        columns: 100,
+        rows: 30,
+        isTty: false,
+        env: {},
+      }).screenEnabled,
+    ).toBe(false);
+  });
+
   it("parses supported color modes", () => {
     expect(parseTerminalColorMode("auto")).toBe("auto");
     expect(parseTerminalColorMode("always")).toBe("always");

--- a/src/terminal/runtime.ts
+++ b/src/terminal/runtime.ts
@@ -11,6 +11,7 @@ export type TerminalSize = {
 export type TerminalRuntime = {
   readonly colorMode: TerminalColorMode;
   readonly colorEnabled: boolean;
+  readonly screenEnabled: boolean;
   readonly theme: TerminalThemeId;
   readonly reducedMotion: boolean;
   readonly size: TerminalSize;
@@ -36,6 +37,7 @@ export function resolveTerminalRuntime(options: TerminalRuntimeOptions): Termina
   return {
     colorMode,
     colorEnabled: resolveColorEnabled(colorMode, options),
+    screenEnabled: options.isTty,
     theme: theme.id,
     reducedMotion: options.reducedMotion || options.env["KEYQUEST_REDUCED_MOTION"] === "1",
     size: {

--- a/src/terminal/screen.test.ts
+++ b/src/terminal/screen.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { TextOutput } from "../cli/text-output.js";
+import { createScreenRenderer, formatRedrawBody } from "./screen.js";
+import type { TerminalRuntime } from "./runtime.js";
+
+describe("screen renderer", () => {
+  it("redraws the screen when terminal screen rendering is enabled", () => {
+    const output = createMemoryOutput();
+    createScreenRenderer({
+      textOutput: output,
+      runtime: createRuntime({ screenEnabled: true, rows: 24 }),
+    }).render(["Title", "1. Start"]);
+
+    expect(output.text()).toBe("\u001b[2J\u001b[HTitle\n1. Start\n");
+  });
+
+  it("falls back to plain output when screen rendering is disabled", () => {
+    const output = createMemoryOutput();
+    createScreenRenderer({
+      textOutput: output,
+      runtime: createRuntime({ screenEnabled: false, rows: 24 }),
+    }).render(["Title", "1. Start"]);
+
+    expect(output.text()).toBe("Title\n1. Start\n");
+  });
+
+  it("truncates redraw bodies to avoid terminal scrolling", () => {
+    expect(
+      formatRedrawBody(["a", "b", "c", "d"], createRuntime({ screenEnabled: true, rows: 3 })),
+    ).toBe("a\n... 3 more lines");
+  });
+});
+
+function createRuntime(options: {
+  readonly screenEnabled: boolean;
+  readonly rows: number;
+}): TerminalRuntime {
+  return {
+    colorMode: "never",
+    colorEnabled: false,
+    screenEnabled: options.screenEnabled,
+    theme: "classic",
+    reducedMotion: false,
+    size: {
+      columns: 80,
+      rows: options.rows,
+      isBelowMinimum: false,
+    },
+  };
+}
+
+function createMemoryOutput(): TextOutput & { readonly text: () => string } {
+  const chunks: string[] = [];
+
+  return {
+    write(text: string): void {
+      chunks.push(text);
+    },
+    writeLine(text: string): void {
+      chunks.push(`${text}\n`);
+    },
+    text(): string {
+      return chunks.join("");
+    },
+  };
+}

--- a/src/terminal/screen.ts
+++ b/src/terminal/screen.ts
@@ -1,0 +1,55 @@
+import type { TextOutput } from "../cli/text-output.js";
+import type { TerminalRuntime } from "./runtime.js";
+
+export type ScreenRenderer = {
+  readonly render: (lines: readonly string[] | string) => void;
+};
+
+const CLEAR_SCREEN_AND_HOME = "\u001b[2J\u001b[H";
+const DEFAULT_SCREEN_ROWS = 24;
+const RESERVED_PROMPT_ROWS = 1;
+
+export function createScreenRenderer(options: {
+  readonly textOutput: TextOutput;
+  readonly runtime: TerminalRuntime | undefined;
+}): ScreenRenderer {
+  return {
+    render(lines: readonly string[] | string): void {
+      const renderedLines = normalizeLines(lines);
+      const body =
+        options.runtime?.screenEnabled === true
+          ? formatRedrawBody(renderedLines, options.runtime)
+          : renderedLines.join("\n");
+
+      if (options.runtime?.screenEnabled === true) {
+        options.textOutput.write(`${CLEAR_SCREEN_AND_HOME}${body}\n`);
+        return;
+      }
+
+      options.textOutput.writeLine(body);
+    },
+  };
+}
+
+export function formatRedrawBody(
+  lines: readonly string[],
+  runtime: TerminalRuntime | undefined,
+): string {
+  const maxRows = Math.max(1, (runtime?.size.rows ?? DEFAULT_SCREEN_ROWS) - RESERVED_PROMPT_ROWS);
+
+  if (lines.length <= maxRows) {
+    return lines.join("\n");
+  }
+
+  return [...lines.slice(0, maxRows - 1), `... ${lines.length - maxRows + 1} more lines`].join(
+    "\n",
+  );
+}
+
+function normalizeLines(lines: readonly string[] | string): readonly string[] {
+  if (typeof lines === "string") {
+    return lines.split("\n");
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary
- Add a terminal screen renderer that clears and redraws interactive TTY screens.
- Keep non-TTY output as plain append-only text for logs and tests.
- Route title, options, practice, segment, and final result screens through the renderer.
- Cap rendered screen bodies to terminal height to avoid scrollback movement.

## Test plan
- npm run verify

Closes #115

Made with [Cursor](https://cursor.com)