### PR TITLE
Document non-scrolling screen rendering

### DIFF
--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -61,6 +61,7 @@ stable.
 - Five initial color themes using semantic color names
 - Reduced-motion setting and policy
 - Screen rendering boundary that keeps ANSI control away from core game logic
+- Non-scrolling redraw path for major terminal screens
 - Input boundary that can support both line input and raw key input
 
 Exit criteria:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -49,9 +49,11 @@
 - [x] Add weak-key review quest generation from mistake history.
 - [x] Wire weak-key review prompts into a selectable review quest.
 - [x] Add Meadow Road clear message and first second-week title reward.
+- [x] Add non-scrolling terminal screen rendering for major screens.
 - [ ] Add River Gate clear message and third-week title reward.
 - [ ] Add Day 22 through Day 28 lessons.
 - [ ] Add review quest result messaging that explains the targeted weak keys.
+- [ ] Add raw-mode real-time typing screen on top of the screen renderer.
 
 ## Mid Term
 

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -59,6 +59,24 @@ Show only what the player needs now.
 This keeps the interface clean while still allowing satisfying RPG and
 incremental feedback.
 
+## Non-Scrolling Screen Rendering
+
+Interactive terminal screens should redraw in place instead of appending every
+state change to scrollback.
+
+Current policy:
+
+- Use the screen renderer for title, options, practice intro, segment result,
+  and final result screens.
+- In TTY output, clear the screen and move the cursor home before drawing the
+  next major screen.
+- In non-TTY output, keep append-only plain text so logs, tests, and piped runs
+  stay readable.
+- Cap redraw output to the known terminal height, reserving one row for the input
+  prompt, so a screen body does not force scrolling.
+- Keep raw ANSI control inside terminal modules; scene and game logic should
+  continue to return semantic text.
+
 ## Terminal Size
 
 Recommended minimum terminal size:


### PR DESCRIPTION
## Summary
- Document the non-scrolling screen renderer policy.
- Mark major-screen redraw rendering complete in TODOs.
- Note the next UI step: raw-mode real-time typing on top of the renderer.

## Test plan
- npm run verify

Closes #117

Made with [Cursor](https://cursor.com)