### PR TITLE
Add River Gate clear reward

### DIFF
--- a/docs/ACHIEVEMENTS.md
+++ b/docs/ACHIEVEMENTS.md
@@ -107,3 +107,4 @@ Implemented title rewards:
 
 - Novice Hall Graduate: clear the Day 7 Gatekeeper Trial.
 - Meadow Road Pathfinder: clear the Day 14 Waystone Trial.
+- River Gate Ferryman: clear the Day 21 Ferryman Trial.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -97,8 +97,8 @@ system too early.
 
 - First reward screen with XP gain
 - Simple level-up display for skill tracks
-- First title rewards after Gatekeeper Trial and Waystone Trial
-  (`noviceHallGraduate`, `meadowRoadPathfinder`)
+- First title rewards after Gatekeeper Trial, Waystone Trial, and Ferryman Trial
+  (`noviceHallGraduate`, `meadowRoadPathfinder`, `riverGateFerryman`)
 - First achievement unlock path for first session, perfect sessions,
   streak milestones, and long-session play
 - Daily streak progression from session completion dates

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,7 +50,7 @@
 - [x] Wire weak-key review prompts into a selectable review quest.
 - [x] Add Meadow Road clear message and first second-week title reward.
 - [x] Add non-scrolling terminal screen rendering for major screens.
-- [ ] Add River Gate clear message and third-week title reward.
+- [x] Add River Gate clear message and third-week title reward.
 - [ ] Add Day 22 through Day 28 lessons.
 - [ ] Add review quest result messaging that explains the targeted weak keys.
 - [x] Add raw-mode real-time typing screen on top of the screen renderer.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -133,6 +133,35 @@ describe("runApp", () => {
     expect(output.text()).toContain("Earned title: Meadow Road Pathfinder");
   });
 
+  it("shows River Gate clear and third-week title after Day 21", async () => {
+    const directory = await createTempDirectory();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    await createSaveStore({ mode: "development", directory }).write({
+      ...createNewSave(now, "development"),
+      journey: {
+        day: 21,
+        chapter: 3,
+        storyFlag: "noviceHallStarted",
+      },
+    });
+    const output = createMemoryOutput();
+
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now,
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Ferryman Trial cleared");
+    expect(output.text()).toContain("Earned title: River Gate Ferryman");
+    expect(output.text()).not.toContain("Next lesson:");
+  });
+
   it("uses lesson session prompt count overrides", async () => {
     const output = createMemoryOutput();
     await runApp({

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -83,10 +83,12 @@ const EN_MESSAGES = {
   "titleReward.unlocked": "Earned title: {title}",
   "titleReward.noviceHallGraduate": "Novice Hall Graduate",
   "titleReward.meadowRoadPathfinder": "Meadow Road Pathfinder",
+  "titleReward.riverGateFerryman": "River Gate Ferryman",
   "journey.heading": "Journey",
   "journey.nextDay": "Next lesson: Day {day} is ready for next time.",
   "journey.noviceHallClear": "Gatekeeper Trial cleared. The Novice Hall opens the road ahead.",
   "journey.meadowRoadClear": "Waystone Trial cleared. The Meadow Road opens into wider lands.",
+  "journey.riverGateClear": "Ferryman Trial cleared. The River Gate yields to your steady hands.",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -168,11 +170,14 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "titleReward.unlocked": "獲得称号: {title}",
     "titleReward.noviceHallGraduate": "Novice Hall 卒業生",
     "titleReward.meadowRoadPathfinder": "Meadow Road の開拓者",
+    "titleReward.riverGateFerryman": "River Gate の渡し守",
     "journey.heading": "旅路",
     "journey.nextDay": "次回は Day {day} のレッスンに進めます。",
     "journey.noviceHallClear": "Gatekeeper Trial クリア。Novice Hall の先の道が開きました。",
     "journey.meadowRoadClear":
       "Waystone Trial クリア。Meadow Road はさらに広い土地へ続いています。",
+    "journey.riverGateClear":
+      "Ferryman Trial クリア。River Gate はあなたの落ち着いた指に道を譲りました。",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -7,6 +7,7 @@ export type BundledLessonManifestEntry = {
 
 export const NOVICE_HALL_FINAL_DAY = 7;
 export const MEADOW_ROAD_FINAL_DAY = 14;
+export const RIVER_GATE_FINAL_DAY = 21;
 
 export const BUNDLED_LESSON_MANIFEST = [
   {

--- a/src/rewards/titles.test.ts
+++ b/src/rewards/titles.test.ts
@@ -62,4 +62,23 @@ describe("title rewards", () => {
       },
     ]);
   });
+
+  it("unlocks River Gate ferryman title after Day 21", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const save = {
+      ...createNewSave(now, "normal"),
+      journey: {
+        day: 21,
+        chapter: 3,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(unlockSessionTitles({ save, unlockedAt: now })).toEqual([
+      {
+        id: "riverGateFerryman",
+        unlockedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
 });

--- a/src/rewards/titles.ts
+++ b/src/rewards/titles.ts
@@ -1,4 +1,8 @@
-import { MEADOW_ROAD_FINAL_DAY, NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
+import {
+  MEADOW_ROAD_FINAL_DAY,
+  NOVICE_HALL_FINAL_DAY,
+  RIVER_GATE_FINAL_DAY,
+} from "../lessons/manifest.js";
 import type { KeyQuestSave, TitleRewardId, TitleRewardRecord } from "../save/model.js";
 
 export type TitleRewardDefinition = {
@@ -15,6 +19,10 @@ export const TITLE_REWARDS: Readonly<Record<TitleRewardId, TitleRewardDefinition
     id: "meadowRoadPathfinder",
     title: "Meadow Road Pathfinder",
   },
+  riverGateFerryman: {
+    id: "riverGateFerryman",
+    title: "River Gate Ferryman",
+  },
 };
 
 export function unlockSessionTitles(options: {
@@ -24,6 +32,7 @@ export function unlockSessionTitles(options: {
   const candidates: TitleRewardId[] = [
     options.save.journey.day === NOVICE_HALL_FINAL_DAY ? "noviceHallGraduate" : undefined,
     options.save.journey.day === MEADOW_ROAD_FINAL_DAY ? "meadowRoadPathfinder" : undefined,
+    options.save.journey.day === RIVER_GATE_FINAL_DAY ? "riverGateFerryman" : undefined,
   ].filter((id): id is TitleRewardId => id !== undefined);
   const existingTitleIds = new Set((options.save.progress.titles ?? []).map((title) => title.id));
 

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -32,7 +32,7 @@ export type AchievementRecord = {
   readonly unlockedAt: string;
 };
 
-export type TitleRewardId = "noviceHallGraduate" | "meadowRoadPathfinder";
+export type TitleRewardId = "noviceHallGraduate" | "meadowRoadPathfinder" | "riverGateFerryman";
 
 export type TitleRewardRecord = {
   readonly id: TitleRewardId;

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -113,6 +113,27 @@ describe("scene rendering", () => {
     ).toEqual(["Journey", "Waystone Trial cleared. The Meadow Road opens into wider lands."]);
   });
 
+  it("renders the River Gate clear message on the Ferryman Trial day", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 21,
+        chapter: 3,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave,
+          afterSave: beforeSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Journey", "Ferryman Trial cleared. The River Gate yields to your steady hands."]);
+  });
+
   it("renders streak milestone progress", () => {
     const beforeSave = {
       ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -10,7 +10,11 @@ import type {
   SceneContext,
   SceneOutput,
 } from "./types.js";
-import { MEADOW_ROAD_FINAL_DAY, NOVICE_HALL_FINAL_DAY } from "../lessons/manifest.js";
+import {
+  MEADOW_ROAD_FINAL_DAY,
+  NOVICE_HALL_FINAL_DAY,
+  RIVER_GATE_FINAL_DAY,
+} from "../lessons/manifest.js";
 import { styleText } from "../terminal/ansi.js";
 
 export const titleScene: Scene = {
@@ -284,6 +288,7 @@ export function renderPracticeJourneyProgress(
   const progressLines = [
     beforeDay === NOVICE_HALL_FINAL_DAY ? t("journey.noviceHallClear") : "",
     beforeDay === MEADOW_ROAD_FINAL_DAY ? t("journey.meadowRoadClear") : "",
+    beforeDay === RIVER_GATE_FINAL_DAY ? t("journey.riverGateClear") : "",
     afterDay > beforeDay ? t("journey.nextDay", { day: afterDay }) : "",
   ].filter((line) => line.length > 0);
 


### PR DESCRIPTION
## Summary
- Add `RIVER_GATE_FINAL_DAY` and a Day 21 Ferryman Trial clear message.
- Add the `riverGateFerryman` title reward and localized title text.
- Cover the title unlock, scene rendering, and app-level Day 21 result path with tests.

## Test plan
- npm run verify

Closes #121

Made with [Cursor](https://cursor.com)