### PR TITLE
Explain weak-key review targets

### DIFF
--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -123,6 +123,7 @@ Goal: make lessons easy to write, review, and improve.
 - Bundled lesson manifest for default progression
 - Weak-key review prompt generation from mistake history
 - Selectable weak-key review quest from the title menu
+- Review quest result messaging that explains the targeted weak keys
 - Programmer symbol lessons
 - Lesson validation command included in `npm run verify`
 - English-only typing prompts separated from localized UI strings

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,7 +52,7 @@
 - [x] Add non-scrolling terminal screen rendering for major screens.
 - [x] Add River Gate clear message and third-week title reward.
 - [ ] Add Day 22 through Day 28 lessons.
-- [ ] Add review quest result messaging that explains the targeted weak keys.
+- [x] Add review quest result messaging that explains the targeted weak keys.
 - [x] Add raw-mode real-time typing screen on top of the screen renderer.
 
 ## Mid Term

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -41,6 +41,7 @@ describe("runApp", () => {
     expect(output.text()).toContain("Time: 20.0s");
     expect(output.text()).toContain("XP gained");
     expect(output.text()).toContain("Rewards");
+    expect(output.text()).not.toContain("Review Focus");
     expect(output.text()).toContain("Achievements");
     expect(output.text()).toContain("Unlocked: First Steps");
     expect(output.text()).toContain("Unlocked: Flawless Focus");
@@ -520,6 +521,8 @@ describe("runApp", () => {
 
     const updatedSave = await createSaveStore({ mode: "normal", directory }).loadOrCreate(now);
     expect(output.text()).toContain("Lesson: Weak-Key Review");
+    expect(output.text()).toContain("Review Focus");
+    expect(output.text()).toContain("Targeted weak keys: j f");
     expect(output.text()).toContain("Prompts: 1");
     expect(updatedSave.journey.day).toBe(1);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import {
   practiceIntroScene,
   renderPracticeAchievements,
   renderPracticeJourneyProgress,
+  renderPracticeReviewResult,
   renderPracticeRunResult,
   renderPracticeRewards,
   renderPracticeSegmentResult,
@@ -180,6 +181,16 @@ export async function runApp(options: RunAppOptions): Promise<void> {
       },
       translator,
     ),
+    ...(reviewPrompt === undefined
+      ? []
+      : [
+          renderPracticeReviewResult(
+            {
+              targetKeys: reviewPrompt.targetKeys,
+            },
+            translator,
+          ),
+        ]),
     renderPracticeRewards(
       {
         beforeSave: menuSave,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -25,6 +25,8 @@ const EN_MESSAGES = {
   "title.menu.loadUnavailable": "Load Game will open save slots later. Use Continue for now.",
   "review.lessonTitle": "Weak-Key Review",
   "review.noMistakes": "No weak-key review is ready yet. Finish a session with mistakes first.",
+  "review.resultHeading": "Review Focus",
+  "review.targetKeys": "Targeted weak keys: {keys}",
   "terminal.sizeWarning": "WARNING: Terminal is {columns}x{rows}. Recommended minimum is 80x24.",
   "options.heading": "Options",
   "options.language": "Language",
@@ -111,6 +113,8 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "review.lessonTitle": "弱点キー復習",
     "review.noMistakes":
       "弱点キー復習はまだありません。まずミスのあるセッションを完了してください。",
+    "review.resultHeading": "復習フォーカス",
+    "review.targetKeys": "今回狙った弱点キー: {keys}",
     "terminal.sizeWarning":
       "WARNING: 端末サイズは {columns}x{rows} です。推奨最小サイズは 80x24 です。",
     "options.heading": "オプション",

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -5,6 +5,7 @@ import { createNewSave } from "../save/model.js";
 import {
   renderPracticeAchievements,
   renderPracticeJourneyProgress,
+  renderPracticeReviewResult,
   renderPracticeRewards,
   renderPracticeStreakProgress,
   renderPracticeTitleRewards,
@@ -90,6 +91,17 @@ describe("scene rendering", () => {
         createTranslator("en"),
       ),
     ).toEqual(["Titles", "Earned title: Novice Hall Graduate"]);
+  });
+
+  it("renders weak-key review target keys", () => {
+    expect(
+      renderPracticeReviewResult(
+        {
+          targetKeys: ["j", "f"],
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual(["Review Focus", "Targeted weak keys: j f"]);
   });
 
   it("renders the Meadow Road clear message on the Waystone Trial day", () => {

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,6 +1,7 @@
 import type {
   PracticeAchievementsView,
   PracticeJourneyProgressView,
+  PracticeReviewResultView,
   PracticeRewardsView,
   PracticeResultView,
   PracticeRunResultView,
@@ -203,6 +204,15 @@ export function renderPracticeRewards(
   });
 
   return [t("reward.heading"), ...rewardLines];
+}
+
+export function renderPracticeReviewResult(
+  review: PracticeReviewResultView,
+  translator: SceneContext["translator"],
+): readonly string[] {
+  const { t } = translator;
+
+  return [t("review.resultHeading"), t("review.targetKeys", { keys: review.targetKeys.join(" ") })];
 }
 
 export function renderPracticeStreakProgress(

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -48,6 +48,10 @@ export type PracticeRewardsView = {
   readonly afterSave: KeyQuestSave;
 };
 
+export type PracticeReviewResultView = {
+  readonly targetKeys: readonly string[];
+};
+
 export type PracticeStreakProgressView = {
   readonly beforeSave: KeyQuestSave;
   readonly afterSave: KeyQuestSave;


### PR DESCRIPTION
## Summary
- Add a review result section that lists targeted weak keys after review quests.
- Keep normal practice results free of review-specific messaging.
- Update short-term docs and TODO state.

## Test plan
- npm run verify

Closes #123

Made with [Cursor](https://cursor.com)