### PR TITLE
Fallback when raw mode is unavailable

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -9,6 +9,7 @@ import type { TextInput } from "./cli/text-input.js";
 import type { TextOutput } from "./cli/text-output.js";
 import type { Lesson } from "./lessons/schema.js";
 import type { RealtimeTypingInput } from "./realtime/input.js";
+import { RawModeUnavailableError } from "./realtime/raw-mode.js";
 import { createNewSave } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 
@@ -340,6 +341,37 @@ describe("runApp", () => {
     expect(output.text()).toContain("Unlocked: Flawless Focus");
   });
 
+  it("falls back to line input when raw mode is unavailable", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      realtimeInput: createUnavailableRealtimeInput(),
+      terminalRuntime: {
+        colorMode: "never",
+        colorEnabled: false,
+        screenEnabled: true,
+        theme: "classic",
+        reducedMotion: false,
+        size: {
+          columns: 100,
+          rows: 30,
+          isBelowMinimum: false,
+        },
+      },
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).not.toContain("Real-time Practice");
+    expect(output.text()).toContain("Session Result");
+    expect(output.text()).toContain("Unlocked: Flawless Focus");
+  });
+
   it("warns when the terminal is below the recommended size", async () => {
     const output = createMemoryOutput();
     await runApp({
@@ -655,6 +687,21 @@ function createQueuedRealtimeInput(keys: readonly string[]): RealtimeTypingInput
     },
     async withRawMode<T>(run: () => Promise<T> | T): Promise<T> {
       return run();
+    },
+  };
+}
+
+function createUnavailableRealtimeInput(): RealtimeTypingInput {
+  return {
+    readKey(): Promise<string> {
+      return Promise.reject(new Error("raw key should not be read"));
+    },
+    withRawMode(): Promise<never> {
+      return Promise.reject(
+        new RawModeUnavailableError(
+          new TypeError("Cannot read properties of undefined (reading '_handle')"),
+        ),
+      );
     },
   };
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { styleText } from "./terminal/ansi.js";
 import type { TerminalRuntime } from "./terminal/runtime.js";
 import { createScreenRenderer, type ScreenRenderer } from "./terminal/screen.js";
 import type { RealtimeTypingInput } from "./realtime/input.js";
+import { isRawModeUnavailableError } from "./realtime/raw-mode.js";
 import { runRealtimeTypingPrompt } from "./realtime/typing-screen.js";
 
 export type RunAppOptions = {
@@ -251,12 +252,18 @@ async function readPracticeInput(options: {
   readonly terminalRuntime: TerminalRuntime | undefined;
 }): Promise<string> {
   if (options.terminalRuntime?.screenEnabled === true && options.realtimeInput !== undefined) {
-    return runRealtimeTypingPrompt({
-      prompt: options.practicePrompt,
-      input: options.realtimeInput,
-      screen: options.screen,
-      translator: options.translator,
-    });
+    try {
+      return await runRealtimeTypingPrompt({
+        prompt: options.practicePrompt,
+        input: options.realtimeInput,
+        screen: options.screen,
+        translator: options.translator,
+      });
+    } catch (error) {
+      if (!isRawModeUnavailableError(error)) {
+        throw error;
+      }
+    }
   }
 
   return options.textInput.readLine("> ");

--- a/src/realtime/raw-mode.test.ts
+++ b/src/realtime/raw-mode.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { toTypingInputFromKey, withRawMode, type RawModeStream } from "./raw-mode.js";
+import {
+  isRawModeUnavailableError,
+  toTypingInputFromKey,
+  withRawMode,
+  type RawModeStream,
+} from "./raw-mode.js";
 
 describe("raw mode helpers", () => {
   it("restores raw mode after successful runs", async () => {
@@ -37,6 +42,19 @@ describe("raw mode helpers", () => {
     await withRawMode(stream, () => "ok");
 
     expect(calls).toEqual([]);
+  });
+
+  it("reports raw-mode startup failures as unavailable", async () => {
+    const stream: RawModeStream = {
+      isTTY: true,
+      setRawMode(): void {
+        throw new TypeError("Cannot read properties of undefined (reading '_handle')");
+      },
+    };
+
+    await expect(withRawMode(stream, () => "ok")).rejects.toSatisfy((error: unknown) =>
+      isRawModeUnavailableError(error),
+    );
   });
 
   it("maps terminal keys to typing inputs", () => {

--- a/src/realtime/raw-mode.ts
+++ b/src/realtime/raw-mode.ts
@@ -7,6 +7,18 @@ export type RawModeStream = {
   readonly pause?: () => void;
 };
 
+export class RawModeUnavailableError extends Error {
+  constructor(cause: unknown) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(`Raw mode is unavailable: ${message}`);
+    this.name = "RawModeUnavailableError";
+  }
+}
+
+export function isRawModeUnavailableError(error: unknown): error is RawModeUnavailableError {
+  return error instanceof RawModeUnavailableError;
+}
+
 export async function withRawMode<T>(stream: RawModeStream, run: () => Promise<T> | T): Promise<T> {
   const setRawMode = stream.setRawMode;
   const shouldUseRawMode = stream.isTTY === true && setRawMode !== undefined;
@@ -15,7 +27,11 @@ export async function withRawMode<T>(stream: RawModeStream, run: () => Promise<T
     return run();
   }
 
-  setRawMode(true);
+  try {
+    setRawMode(true);
+  } catch (error) {
+    throw new RawModeUnavailableError(error);
+  }
   stream.resume?.();
 
   try {


### PR DESCRIPTION
## Summary
- Convert raw-mode startup failures into a dedicated unavailable capability error.
- Fall back to line input when realtime raw mode cannot start, instead of exiting to the shell.
- Add regression coverage for `_handle` startup failures and app-level fallback behavior.

## Test plan
- npm run verify

Closes #125

Made with [Cursor](https://cursor.com)