### PR TITLE
Add Lantern Keep lessons

### DIFF
--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -119,6 +119,7 @@ Goal: make lessons easy to write, review, and improve.
 - Beginner home-row lessons through the first Novice Hall week
 - First Meadow Road lessons through Day 14
 - First River Gate lessons through Day 21
+- First Lantern Keep lessons through Day 28
 - Lesson-specific session prompt counts for boss-style lessons
 - Bundled lesson manifest for default progression
 - Weak-key review prompt generation from mistake history

--- a/docs/ONBOARDING_TRAINING.md
+++ b/docs/ONBOARDING_TRAINING.md
@@ -65,6 +65,23 @@ session length.
 The Day 21 checkpoint is the first weekly trial that includes punctuation. It
 should still reward calm accuracy over speed.
 
+## Days 22-28
+
+The fourth week begins the "Lantern Keep" arc. It introduces the number row in
+small, practical pieces before mixing digits into readable English prompts.
+
+- Day 22: left number row with `1`, `2`, `3`, and `4`.
+- Day 23: right number row with `7`, `8`, `9`, and `0`.
+- Day 24: center number span with `4`, `5`, `6`, and `7`.
+- Day 25: short counts and codes in simple phrases.
+- Day 26: map labels and room numbers.
+- Day 27: mixed number-row instructions.
+- Day 28: Beacon Trial checkpoint for number-row control.
+
+The Day 28 checkpoint should confirm that digits can be typed without losing
+home-position discipline. It still avoids Shift-heavy symbols so the player can
+lock in number-row reach before the next layer of complexity.
+
 ### Day 1: Novice Stance
 
 Player goal: learn that good typing starts from calm finger placement.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -51,7 +51,7 @@
 - [x] Add Meadow Road clear message and first second-week title reward.
 - [x] Add non-scrolling terminal screen rendering for major screens.
 - [x] Add River Gate clear message and third-week title reward.
-- [ ] Add Day 22 through Day 28 lessons.
+- [x] Add Day 22 through Day 28 lessons.
 - [x] Add review quest result messaging that explains the targeted weak keys.
 - [x] Add raw-mode real-time typing screen on top of the screen renderer.
 

--- a/lessons/lantern-keep-day-22.json
+++ b/lessons/lantern-keep-day-22.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-22",
+  "title": "Lantern Keep: Left Number Row",
+  "day": 22,
+  "locale": "en",
+  "focus": ["left number row", "upper reach", "accuracy"],
+  "prompts": [
+    {
+      "id": "lantern-left-number-1",
+      "text": "1 2 3 4",
+      "targetKeys": ["1", "2", "3", "4"],
+      "skillIds": ["fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftPinky", "leftRing", "leftMiddle", "leftIndex"]
+    },
+    {
+      "id": "lantern-left-number-2",
+      "text": "11 22 33 44",
+      "targetKeys": ["1", "2", "3", "4"],
+      "skillIds": ["fingerResponsibility", "rhythm"],
+      "fingerHints": ["leftPinky", "leftRing", "leftMiddle", "leftIndex"]
+    },
+    {
+      "id": "lantern-left-number-3",
+      "text": "room 12 gate 34",
+      "targetKeys": ["r", "o", "m", "1", "2", "g", "a", "t", "e", "3", "4"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "rightRing",
+        "rightIndex",
+        "leftPinky",
+        "leftRing",
+        "leftIndex",
+        "leftPinky",
+        "leftIndex",
+        "leftMiddle",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-23.json
+++ b/lessons/lantern-keep-day-23.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-23",
+  "title": "Lantern Keep: Right Number Row",
+  "day": 23,
+  "locale": "en",
+  "focus": ["right number row", "upper reach", "rhythm"],
+  "prompts": [
+    {
+      "id": "lantern-right-number-1",
+      "text": "7 8 9 0",
+      "targetKeys": ["7", "8", "9", "0"],
+      "skillIds": ["fingerResponsibility", "accuracy"],
+      "fingerHints": ["rightIndex", "rightMiddle", "rightRing", "rightPinky"]
+    },
+    {
+      "id": "lantern-right-number-2",
+      "text": "77 88 99 00",
+      "targetKeys": ["7", "8", "9", "0"],
+      "skillIds": ["fingerResponsibility", "rhythm"],
+      "fingerHints": ["rightIndex", "rightMiddle", "rightRing", "rightPinky"]
+    },
+    {
+      "id": "lantern-right-number-3",
+      "text": "tower 78 path 90",
+      "targetKeys": ["t", "o", "w", "e", "r", "7", "8", "p", "a", "h", "9", "0"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "rightRing",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightPinky",
+        "leftPinky",
+        "rightIndex",
+        "rightRing",
+        "rightPinky"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-24.json
+++ b/lessons/lantern-keep-day-24.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-24",
+  "title": "Lantern Keep: Center Span",
+  "day": 24,
+  "locale": "en",
+  "focus": ["center number row", "index reach", "steady return"],
+  "prompts": [
+    {
+      "id": "lantern-center-span-1",
+      "text": "4 5 6 7",
+      "targetKeys": ["4", "5", "6", "7"],
+      "skillIds": ["fingerResponsibility", "accuracy"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "rightIndex"]
+    },
+    {
+      "id": "lantern-center-span-2",
+      "text": "45 56 67 76 65 54",
+      "targetKeys": ["4", "5", "6", "7"],
+      "skillIds": ["fingerResponsibility", "rhythm"],
+      "fingerHints": ["leftIndex", "leftIndex", "rightIndex", "rightIndex"]
+    },
+    {
+      "id": "lantern-center-span-3",
+      "text": "level 45 bridge 67",
+      "targetKeys": ["l", "e", "v", "4", "5", "b", "r", "i", "d", "g", "6", "7"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "rightRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "leftIndex",
+        "leftIndex",
+        "leftIndex",
+        "rightMiddle",
+        "leftMiddle",
+        "leftIndex",
+        "rightIndex",
+        "rightIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-25.json
+++ b/lessons/lantern-keep-day-25.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-25",
+  "title": "Lantern Keep: Counts And Codes",
+  "day": 25,
+  "locale": "en",
+  "focus": ["number words", "short codes", "accuracy under context"],
+  "prompts": [
+    {
+      "id": "lantern-counts-1",
+      "text": "take 2 keys and 3 maps",
+      "targetKeys": ["t", "a", "k", "e", "2", "y", "s", "3", "m", "p"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftPinky",
+        "rightMiddle",
+        "leftMiddle",
+        "leftRing",
+        "rightIndex",
+        "leftRing",
+        "leftMiddle",
+        "rightIndex",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "lantern-counts-2",
+      "text": "mark 4 rooms before 5",
+      "targetKeys": ["m", "a", "r", "k", "4", "o", "s", "b", "e", "f", "5"],
+      "skillIds": ["fingerResponsibility", "homeRow", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "leftPinky",
+        "leftIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightRing",
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex"
+      ]
+    },
+    {
+      "id": "lantern-counts-3",
+      "text": "code 120 opens gate 34",
+      "targetKeys": ["c", "o", "d", "e", "1", "2", "0", "p", "n", "s", "g", "a", "t", "3", "4"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftMiddle",
+        "rightRing",
+        "leftMiddle",
+        "leftMiddle",
+        "leftPinky",
+        "leftRing",
+        "rightPinky",
+        "rightPinky",
+        "rightIndex",
+        "leftRing",
+        "leftIndex",
+        "leftPinky",
+        "leftIndex",
+        "leftMiddle",
+        "leftIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-26.json
+++ b/lessons/lantern-keep-day-26.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-26",
+  "title": "Lantern Keep: Map Marks",
+  "day": 26,
+  "locale": "en",
+  "focus": ["map labels", "mixed rows", "number accuracy"],
+  "prompts": [
+    {
+      "id": "lantern-map-marks-1",
+      "text": "map 1 room 2 hall 3",
+      "targetKeys": ["m", "a", "p", "1", "r", "o", "2", "h", "l", "3"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "rightIndex",
+        "leftPinky",
+        "rightPinky",
+        "leftPinky",
+        "leftIndex",
+        "rightRing",
+        "leftRing",
+        "rightIndex",
+        "rightRing",
+        "leftMiddle"
+      ]
+    },
+    {
+      "id": "lantern-map-marks-2",
+      "text": "turn 6 then open 7",
+      "targetKeys": ["t", "u", "r", "n", "6", "h", "e", "o", "p", "7"],
+      "skillIds": ["fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "rightIndex",
+        "leftIndex",
+        "rightIndex",
+        "rightIndex",
+        "rightIndex",
+        "leftMiddle",
+        "rightRing",
+        "rightPinky",
+        "rightIndex"
+      ]
+    },
+    {
+      "id": "lantern-map-marks-3",
+      "text": "lamp 8 shows door 9",
+      "targetKeys": ["l", "a", "m", "p", "8", "s", "h", "o", "w", "d", "r", "9"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "rightRing",
+        "leftPinky",
+        "rightIndex",
+        "rightPinky",
+        "rightMiddle",
+        "leftRing",
+        "rightIndex",
+        "rightRing",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-27.json
+++ b/lessons/lantern-keep-day-27.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-27",
+  "title": "Lantern Keep: Mixed Signals",
+  "day": 27,
+  "locale": "en",
+  "focus": ["mixed number row", "short instructions", "steady cadence"],
+  "prompts": [
+    {
+      "id": "lantern-mixed-signals-1",
+      "text": "level 2 map 4 gate 6",
+      "targetKeys": ["l", "e", "v", "2", "m", "a", "p", "4", "g", "t", "6"],
+      "skillIds": ["homePosition", "fingerResponsibility", "rhythm"],
+      "fingerHints": [
+        "rightRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftRing",
+        "rightIndex",
+        "leftPinky",
+        "rightPinky",
+        "leftIndex",
+        "leftIndex",
+        "leftIndex",
+        "rightIndex"
+      ]
+    },
+    {
+      "id": "lantern-mixed-signals-2",
+      "text": "path 8 room 10",
+      "targetKeys": ["p", "a", "t", "h", "8", "r", "o", "m", "1", "0"],
+      "skillIds": ["fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "rightPinky",
+        "leftPinky",
+        "leftIndex",
+        "rightIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightRing",
+        "rightIndex",
+        "leftPinky",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "lantern-mixed-signals-3",
+      "text": "steady hands read signal 27",
+      "targetKeys": ["s", "t", "e", "a", "d", "y", "h", "n", "r", "i", "g", "l", "2", "7"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftRing",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "leftMiddle",
+        "rightIndex",
+        "rightIndex",
+        "rightIndex",
+        "leftIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightRing",
+        "leftRing",
+        "rightIndex"
+      ]
+    }
+  ]
+}

--- a/lessons/lantern-keep-day-28.json
+++ b/lessons/lantern-keep-day-28.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": 1,
+  "id": "lantern-keep-day-28",
+  "title": "Lantern Keep: Beacon Trial",
+  "day": 28,
+  "locale": "en",
+  "focus": ["weekly checkpoint", "number row control", "mixed instruction accuracy"],
+  "sessionPromptCount": 4,
+  "prompts": [
+    {
+      "id": "lantern-trial-1",
+      "text": "1234 567 890",
+      "targetKeys": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
+      "skillIds": ["fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftPinky",
+        "leftRing",
+        "leftMiddle",
+        "leftIndex",
+        "leftIndex",
+        "rightIndex",
+        "rightIndex",
+        "rightMiddle",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "lantern-trial-2",
+      "text": "gate 12 room 34 path 56",
+      "targetKeys": ["g", "a", "t", "e", "1", "2", "r", "o", "m", "3", "4", "p", "h", "5", "6"],
+      "skillIds": ["homePosition", "fingerResponsibility", "accuracy"],
+      "fingerHints": [
+        "leftIndex",
+        "leftPinky",
+        "leftIndex",
+        "leftMiddle",
+        "leftPinky",
+        "leftRing",
+        "leftIndex",
+        "rightRing",
+        "rightIndex",
+        "leftMiddle",
+        "leftIndex",
+        "rightPinky",
+        "rightIndex",
+        "leftIndex",
+        "rightIndex"
+      ]
+    },
+    {
+      "id": "lantern-trial-3",
+      "text": "mark 78 then open 90",
+      "targetKeys": ["m", "a", "r", "k", "7", "8", "t", "h", "e", "n", "o", "p", "9", "0"],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "rhythm"],
+      "fingerHints": [
+        "rightIndex",
+        "leftPinky",
+        "leftIndex",
+        "rightMiddle",
+        "rightIndex",
+        "rightMiddle",
+        "leftIndex",
+        "rightIndex",
+        "leftMiddle",
+        "rightIndex",
+        "rightRing",
+        "rightPinky",
+        "rightRing",
+        "rightPinky"
+      ]
+    },
+    {
+      "id": "lantern-trial-beacon",
+      "text": "the beacon opens at level 28.",
+      "targetKeys": ["t", "h", "e", "b", "a", "c", "o", "n", "p", "s", "l", "v", "2", "8", "."],
+      "skillIds": ["homePosition", "fingerResponsibility", "homeRow", "accuracy", "rhythm"],
+      "fingerHints": [
+        "leftIndex",
+        "rightIndex",
+        "leftMiddle",
+        "leftIndex",
+        "leftPinky",
+        "leftMiddle",
+        "rightRing",
+        "rightIndex",
+        "rightPinky",
+        "leftRing",
+        "rightRing",
+        "leftIndex",
+        "leftRing",
+        "rightMiddle",
+        "rightRing"
+      ]
+    }
+  ]
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -84,8 +84,8 @@ describe("runApp", () => {
     await createSaveStore({ mode: "development", directory }).write({
       ...createNewSave(now, "development"),
       journey: {
-        day: 21,
-        chapter: 2,
+        day: 28,
+        chapter: 4,
         storyFlag: "noviceHallStarted",
       },
     });
@@ -105,6 +105,7 @@ describe("runApp", () => {
     expect(output.text()).not.toContain("Next lesson:");
     expect(output.text()).not.toContain("Gatekeeper Trial cleared");
     expect(output.text()).not.toContain("Waystone Trial cleared");
+    expect(output.text()).not.toContain("Ferryman Trial cleared");
   });
 
   it("shows Meadow Road clear and second-week title after Day 14", async () => {
@@ -161,7 +162,7 @@ describe("runApp", () => {
 
     expect(output.text()).toContain("Ferryman Trial cleared");
     expect(output.text()).toContain("Earned title: River Gate Ferryman");
-    expect(output.text()).not.toContain("Next lesson:");
+    expect(output.text()).toContain("Next lesson: Day 22 is ready for next time.");
   });
 
   it("uses lesson session prompt count overrides", async () => {

--- a/src/lessons/loader.test.ts
+++ b/src/lessons/loader.test.ts
@@ -69,8 +69,10 @@ describe("lesson loader", () => {
     expect(getDefaultLessonPathForDay(14)).toMatch(/lessons\/meadow-road-day-14\.json$/);
     expect(getDefaultLessonPathForDay(15)).toMatch(/lessons\/river-gate-day-15\.json$/);
     expect(getDefaultLessonPathForDay(21)).toMatch(/lessons\/river-gate-day-21\.json$/);
+    expect(getDefaultLessonPathForDay(22)).toMatch(/lessons\/lantern-keep-day-22\.json$/);
+    expect(getDefaultLessonPathForDay(28)).toMatch(/lessons\/lantern-keep-day-28\.json$/);
     expect(() => getDefaultLessonPathForDay(0)).toThrow("positive integer");
-    expect(() => getDefaultLessonPathForDay(22)).toThrow("No bundled lesson");
+    expect(() => getDefaultLessonPathForDay(29)).toThrow("No bundled lesson");
   });
 });
 

--- a/src/lessons/manifest.test.ts
+++ b/src/lessons/manifest.test.ts
@@ -10,9 +10,10 @@ import {
 describe("bundled lesson manifest", () => {
   it("lists bundled lessons in day order", () => {
     expect(BUNDLED_LESSON_MANIFEST.map((lesson) => lesson.day)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28,
     ]);
-    expect(getLatestBundledLessonDay()).toBe(21);
+    expect(getLatestBundledLessonDay()).toBe(28);
   });
 
   it("resolves lessons by day and rejects unavailable days", () => {
@@ -46,8 +47,14 @@ describe("bundled lesson manifest", () => {
       filename: "river-gate-day-21.json",
       title: "River Gate: Ferryman Trial",
     });
+    expect(getBundledLessonForDay(28)).toEqual({
+      day: 28,
+      id: "lantern-keep-day-28",
+      filename: "lantern-keep-day-28.json",
+      title: "Lantern Keep: Beacon Trial",
+    });
     expect(() => getBundledLessonForDay(0)).toThrow("positive integer");
-    expect(() => getBundledLessonForDay(22)).toThrow("No bundled lesson");
+    expect(() => getBundledLessonForDay(29)).toThrow("No bundled lesson");
   });
 
   it("matches bundled lesson files to manifest metadata", async () => {
@@ -105,6 +112,22 @@ describe("bundled lesson manifest", () => {
       "river-gate-trial-2",
       "river-gate-trial-3",
       "river-gate-trial-ferryman",
+    ]);
+  });
+
+  it("selects the Lantern Keep checkpoint prompt in the current Day 28 session", async () => {
+    const lesson = await loadLessonFromFile(getDefaultLessonPathForDay(28));
+    const sessionPromptCount = lesson.sessionPromptCount;
+    if (sessionPromptCount === undefined) {
+      throw new Error("Day 28 must define a session prompt count");
+    }
+
+    expect(lesson.sessionPromptCount).toBe(4);
+    expect(selectPracticePrompts(lesson, sessionPromptCount).map((prompt) => prompt.id)).toEqual([
+      "lantern-trial-1",
+      "lantern-trial-2",
+      "lantern-trial-3",
+      "lantern-trial-beacon",
     ]);
   });
 });

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -136,6 +136,48 @@ export const BUNDLED_LESSON_MANIFEST = [
     filename: "river-gate-day-21.json",
     title: "River Gate: Ferryman Trial",
   },
+  {
+    day: 22,
+    id: "lantern-keep-day-22",
+    filename: "lantern-keep-day-22.json",
+    title: "Lantern Keep: Left Number Row",
+  },
+  {
+    day: 23,
+    id: "lantern-keep-day-23",
+    filename: "lantern-keep-day-23.json",
+    title: "Lantern Keep: Right Number Row",
+  },
+  {
+    day: 24,
+    id: "lantern-keep-day-24",
+    filename: "lantern-keep-day-24.json",
+    title: "Lantern Keep: Center Span",
+  },
+  {
+    day: 25,
+    id: "lantern-keep-day-25",
+    filename: "lantern-keep-day-25.json",
+    title: "Lantern Keep: Counts And Codes",
+  },
+  {
+    day: 26,
+    id: "lantern-keep-day-26",
+    filename: "lantern-keep-day-26.json",
+    title: "Lantern Keep: Map Marks",
+  },
+  {
+    day: 27,
+    id: "lantern-keep-day-27",
+    filename: "lantern-keep-day-27.json",
+    title: "Lantern Keep: Mixed Signals",
+  },
+  {
+    day: 28,
+    id: "lantern-keep-day-28",
+    filename: "lantern-keep-day-28.json",
+    title: "Lantern Keep: Beacon Trial",
+  },
 ] as const satisfies readonly BundledLessonManifestEntry[];
 
 export function getBundledLessonForDay(day: number): BundledLessonManifestEntry {

--- a/src/lessons/validate-bundled.test.ts
+++ b/src/lessons/validate-bundled.test.ts
@@ -26,6 +26,13 @@ describe("bundled lesson validation command", () => {
       "19: river-gate-day-19",
       "20: river-gate-day-20",
       "21: river-gate-day-21",
+      "22: lantern-keep-day-22",
+      "23: lantern-keep-day-23",
+      "24: lantern-keep-day-24",
+      "25: lantern-keep-day-25",
+      "26: lantern-keep-day-26",
+      "27: lantern-keep-day-27",
+      "28: lantern-keep-day-28",
     ]);
   });
 });

--- a/src/practice/session.test.ts
+++ b/src/practice/session.test.ts
@@ -239,7 +239,9 @@ describe("advanceJourneyDay", () => {
     expect(advanceJourneyDay(13)).toBe(14);
     expect(advanceJourneyDay(14)).toBe(15);
     expect(advanceJourneyDay(20)).toBe(21);
-    expect(advanceJourneyDay(21)).toBe(21);
+    expect(advanceJourneyDay(21)).toBe(22);
+    expect(advanceJourneyDay(27)).toBe(28);
+    expect(advanceJourneyDay(28)).toBe(28);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Day 22 through Day 28 Lantern Keep lessons covering number-row practice.
- Extend the bundled lesson manifest and latest progression cap to Day 28.
- Update validation, loader, app, and journey advancement tests plus onboarding docs.

## Test plan
- npm run verify

Closes #127

Made with [Cursor](https://cursor.com)