### PR TITLE
Add Lantern Keep clear reward

### DIFF
--- a/docs/ACHIEVEMENTS.md
+++ b/docs/ACHIEVEMENTS.md
@@ -108,3 +108,4 @@ Implemented title rewards:
 - Novice Hall Graduate: clear the Day 7 Gatekeeper Trial.
 - Meadow Road Pathfinder: clear the Day 14 Waystone Trial.
 - River Gate Ferryman: clear the Day 21 Ferryman Trial.
+- Lantern Keep Beacon: clear the Day 28 Beacon Trial.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -97,8 +97,9 @@ system too early.
 
 - First reward screen with XP gain
 - Simple level-up display for skill tracks
-- First title rewards after Gatekeeper Trial, Waystone Trial, and Ferryman Trial
-  (`noviceHallGraduate`, `meadowRoadPathfinder`, `riverGateFerryman`)
+- First title rewards after Gatekeeper Trial, Waystone Trial, Ferryman Trial,
+  and Beacon Trial (`noviceHallGraduate`, `meadowRoadPathfinder`,
+  `riverGateFerryman`, `lanternKeepBeacon`)
 - First achievement unlock path for first session, perfect sessions,
   streak milestones, and long-session play
 - Daily streak progression from session completion dates

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -106,6 +106,8 @@ describe("runApp", () => {
     expect(output.text()).not.toContain("Gatekeeper Trial cleared");
     expect(output.text()).not.toContain("Waystone Trial cleared");
     expect(output.text()).not.toContain("Ferryman Trial cleared");
+    expect(output.text()).toContain("Beacon Trial cleared");
+    expect(output.text()).toContain("Earned title: Lantern Keep Beacon");
   });
 
   it("shows Meadow Road clear and second-week title after Day 14", async () => {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -86,11 +86,14 @@ const EN_MESSAGES = {
   "titleReward.noviceHallGraduate": "Novice Hall Graduate",
   "titleReward.meadowRoadPathfinder": "Meadow Road Pathfinder",
   "titleReward.riverGateFerryman": "River Gate Ferryman",
+  "titleReward.lanternKeepBeacon": "Lantern Keep Beacon",
   "journey.heading": "Journey",
   "journey.nextDay": "Next lesson: Day {day} is ready for next time.",
   "journey.noviceHallClear": "Gatekeeper Trial cleared. The Novice Hall opens the road ahead.",
   "journey.meadowRoadClear": "Waystone Trial cleared. The Meadow Road opens into wider lands.",
   "journey.riverGateClear": "Ferryman Trial cleared. The River Gate yields to your steady hands.",
+  "journey.lanternKeepClear":
+    "Beacon Trial cleared. The Lantern Keep shines over your number-row reach.",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -175,6 +178,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "titleReward.noviceHallGraduate": "Novice Hall 卒業生",
     "titleReward.meadowRoadPathfinder": "Meadow Road の開拓者",
     "titleReward.riverGateFerryman": "River Gate の渡し守",
+    "titleReward.lanternKeepBeacon": "Lantern Keep の灯火",
     "journey.heading": "旅路",
     "journey.nextDay": "次回は Day {day} のレッスンに進めます。",
     "journey.noviceHallClear": "Gatekeeper Trial クリア。Novice Hall の先の道が開きました。",
@@ -182,6 +186,8 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
       "Waystone Trial クリア。Meadow Road はさらに広い土地へ続いています。",
     "journey.riverGateClear":
       "Ferryman Trial クリア。River Gate はあなたの落ち着いた指に道を譲りました。",
+    "journey.lanternKeepClear":
+      "Beacon Trial クリア。Lantern Keep の灯があなたの数字段の到達を照らしています。",
   },
   "zh-CN": {
     ...EN_MESSAGES,

--- a/src/lessons/manifest.ts
+++ b/src/lessons/manifest.ts
@@ -8,6 +8,7 @@ export type BundledLessonManifestEntry = {
 export const NOVICE_HALL_FINAL_DAY = 7;
 export const MEADOW_ROAD_FINAL_DAY = 14;
 export const RIVER_GATE_FINAL_DAY = 21;
+export const LANTERN_KEEP_FINAL_DAY = 28;
 
 export const BUNDLED_LESSON_MANIFEST = [
   {

--- a/src/rewards/titles.test.ts
+++ b/src/rewards/titles.test.ts
@@ -81,4 +81,23 @@ describe("title rewards", () => {
       },
     ]);
   });
+
+  it("unlocks Lantern Keep beacon title after Day 28", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const save = {
+      ...createNewSave(now, "normal"),
+      journey: {
+        day: 28,
+        chapter: 4,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(unlockSessionTitles({ save, unlockedAt: now })).toEqual([
+      {
+        id: "lanternKeepBeacon",
+        unlockedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
 });

--- a/src/rewards/titles.ts
+++ b/src/rewards/titles.ts
@@ -1,4 +1,5 @@
 import {
+  LANTERN_KEEP_FINAL_DAY,
   MEADOW_ROAD_FINAL_DAY,
   NOVICE_HALL_FINAL_DAY,
   RIVER_GATE_FINAL_DAY,
@@ -23,6 +24,10 @@ export const TITLE_REWARDS: Readonly<Record<TitleRewardId, TitleRewardDefinition
     id: "riverGateFerryman",
     title: "River Gate Ferryman",
   },
+  lanternKeepBeacon: {
+    id: "lanternKeepBeacon",
+    title: "Lantern Keep Beacon",
+  },
 };
 
 export function unlockSessionTitles(options: {
@@ -33,6 +38,7 @@ export function unlockSessionTitles(options: {
     options.save.journey.day === NOVICE_HALL_FINAL_DAY ? "noviceHallGraduate" : undefined,
     options.save.journey.day === MEADOW_ROAD_FINAL_DAY ? "meadowRoadPathfinder" : undefined,
     options.save.journey.day === RIVER_GATE_FINAL_DAY ? "riverGateFerryman" : undefined,
+    options.save.journey.day === LANTERN_KEEP_FINAL_DAY ? "lanternKeepBeacon" : undefined,
   ].filter((id): id is TitleRewardId => id !== undefined);
   const existingTitleIds = new Set((options.save.progress.titles ?? []).map((title) => title.id));
 

--- a/src/save/model.ts
+++ b/src/save/model.ts
@@ -32,7 +32,11 @@ export type AchievementRecord = {
   readonly unlockedAt: string;
 };
 
-export type TitleRewardId = "noviceHallGraduate" | "meadowRoadPathfinder" | "riverGateFerryman";
+export type TitleRewardId =
+  | "noviceHallGraduate"
+  | "meadowRoadPathfinder"
+  | "riverGateFerryman"
+  | "lanternKeepBeacon";
 
 export type TitleRewardRecord = {
   readonly id: TitleRewardId;

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -146,6 +146,30 @@ describe("scene rendering", () => {
     ).toEqual(["Journey", "Ferryman Trial cleared. The River Gate yields to your steady hands."]);
   });
 
+  it("renders the Lantern Keep clear message on the Beacon Trial day", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 28,
+        chapter: 4,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(
+      renderPracticeJourneyProgress(
+        {
+          beforeSave,
+          afterSave: beforeSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual([
+      "Journey",
+      "Beacon Trial cleared. The Lantern Keep shines over your number-row reach.",
+    ]);
+  });
+
   it("renders streak milestone progress", () => {
     const beforeSave = {
       ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -12,6 +12,7 @@ import type {
   SceneOutput,
 } from "./types.js";
 import {
+  LANTERN_KEEP_FINAL_DAY,
   MEADOW_ROAD_FINAL_DAY,
   NOVICE_HALL_FINAL_DAY,
   RIVER_GATE_FINAL_DAY,
@@ -299,6 +300,7 @@ export function renderPracticeJourneyProgress(
     beforeDay === NOVICE_HALL_FINAL_DAY ? t("journey.noviceHallClear") : "",
     beforeDay === MEADOW_ROAD_FINAL_DAY ? t("journey.meadowRoadClear") : "",
     beforeDay === RIVER_GATE_FINAL_DAY ? t("journey.riverGateClear") : "",
+    beforeDay === LANTERN_KEEP_FINAL_DAY ? t("journey.lanternKeepClear") : "",
     afterDay > beforeDay ? t("journey.nextDay", { day: afterDay }) : "",
   ].filter((line) => line.length > 0);
 


### PR DESCRIPTION
## Summary
- Add `LANTERN_KEEP_FINAL_DAY` and a Day 28 Beacon Trial clear message.
- Add the `lanternKeepBeacon` title reward and localized title text.
- Cover title unlock, scene rendering, and app-level latest-day reward behavior.

## Test plan
- npm run verify

Closes #129

Made with [Cursor](https://cursor.com)