### PR TITLE
Add weak-key review quest boundary

### DIFF
--- a/docs/ADVENTURE_PROGRESSION.md
+++ b/docs/ADVENTURE_PROGRESSION.md
@@ -85,6 +85,8 @@ Weak-key review is part of adventure progression, not a separate mini-game.
 - Mistakes become "curses" attached to keys.
 - Review quests target the most frequent recent weak keys.
 - Review results should explain which keys were trained.
+- Review quests carry their own metadata and do not advance the main journey by
+  default.
 - Weekly Day 6 lessons can eventually be replaced or augmented by dynamic review
   when enough history exists.
 - Clearing review should reward accuracy and recovery, not speed.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -145,6 +145,8 @@ Goal: shape daily practice into a 90-day fantasy journey.
 - Documented achievement trigger model, reward policy, and first full
   achievement set
 - Review mode for weak keys
+- Typed weak-key review quest boundary with target-key metadata and no journey
+  advancement
 - HP, MP, weapons, magic, items, and curses mapped to typing behavior
 - First save-backed resource model for quest HP, focus MP, materials, inventory,
   magic, weapons, and curses

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -61,7 +61,7 @@
 - [x] Design [#9](https://github.com/hideyukiMORI/keyquest/issues/9): achievement engine and first achievement set.
 - [x] Add HP, MP, XP, item, magic, weapon, and curse models.
 - [x] Add weekly boss quest rules.
-- [ ] Add weak-key review quests.
+- [x] Add weak-key review quests.
 - [ ] Add Chinese, Korean, Spanish, and Portuguese UI catalogs.
 
 ## Long Term

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import {
   type PracticeAttempt,
   type PracticePrompt,
 } from "./practice/session.js";
-import { createWeakKeyReviewPrompt } from "./practice/weak-key-review.js";
+import { createWeakKeyReviewQuest } from "./quest/review-quest.js";
 import { createNewSave, updateLocale, type KeyQuestSave, type SaveMode } from "./save/model.js";
 import { createSaveStore } from "./save/store.js";
 import { formatSceneSequence, renderSceneSequence } from "./scenes/manager.js";
@@ -86,22 +86,18 @@ export async function runApp(options: RunAppOptions): Promise<void> {
     writeSave: saveStore.write,
   });
   const menuSave = menuSelection.save;
-  const reviewPrompt =
-    menuSelection.action === "review" ? createWeakKeyReviewPrompt(menuSave) : undefined;
+  const reviewQuest =
+    menuSelection.action === "review" ? createWeakKeyReviewQuest({ save: menuSave }) : undefined;
   const defaultLessonPath = getDefaultLessonPathForDay(menuSave.journey.day);
   const lesson =
-    reviewPrompt === undefined
+    reviewQuest === undefined
       ? (options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? defaultLessonPath)))
-      : createReviewLesson(
-          menuSave.journey.day,
-          createTranslator(menuSave.settings.locale).t("review.lessonTitle"),
-          reviewPrompt,
-        );
+      : createReviewLesson(menuSave.journey.day, reviewQuest.title, reviewQuest.prompt);
   const practicePrompts =
-    reviewPrompt === undefined
+    reviewQuest === undefined
       ? selectPracticePrompts(lesson, lesson.sessionPromptCount ?? DAILY_SESSION_PROMPT_COUNT)
-      : [reviewPrompt];
-  const advancesJourney = menuSelection.action !== "review";
+      : [reviewQuest.prompt];
+  const advancesJourney = reviewQuest?.advancesJourney ?? true;
   const translator = createTranslator(menuSave.settings.locale);
   const attempts: PracticeAttempt[] = [];
   let promptStartedAt = now;
@@ -182,12 +178,12 @@ export async function runApp(options: RunAppOptions): Promise<void> {
       },
       translator,
     ),
-    ...(reviewPrompt === undefined
+    ...(reviewQuest === undefined
       ? []
       : [
           renderPracticeReviewResult(
             {
-              targetKeys: reviewPrompt.targetKeys,
+              targetKeys: reviewQuest.targetKeys,
             },
             translator,
           ),
@@ -301,7 +297,7 @@ async function runTitleMenu(options: {
     }
 
     if (action === "review") {
-      if (createWeakKeyReviewPrompt(save) === undefined) {
+      if (createWeakKeyReviewQuest({ save }) === undefined) {
         notice = translator.t("review.noMistakes");
         continue;
       }

--- a/src/quest/review-quest.test.ts
+++ b/src/quest/review-quest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { createNewSave } from "../save/model.js";
+import { createWeakKeyReviewQuest } from "./review-quest.js";
+
+describe("weak-key review quest", () => {
+  it("creates quest metadata from weak-key history", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const save = {
+      ...createNewSave(now, "normal"),
+      progress: {
+        ...createNewSave(now, "normal").progress,
+        sessions: [
+          {
+            id: "session-previous",
+            mode: "normal" as const,
+            startedAt: "2026-01-01T00:00:00.000Z",
+            completedAt: "2026-01-01T00:10:00.000Z",
+            promptCount: 1,
+            accuracy: 0.5,
+            wordsPerMinute: 20,
+            xpGained: 5,
+            mistakes: [
+              { promptId: "p1", index: 0, expected: "j", actual: "f" },
+              { promptId: "p1", index: 1, expected: "j", actual: "f" },
+              { promptId: "p1", index: 2, expected: "f", actual: "j" },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(createWeakKeyReviewQuest({ save })).toMatchObject({
+      id: "weak-key-review",
+      title: "Weak-Key Review",
+      targetKeys: ["j", "f"],
+      advancesJourney: false,
+      prompt: {
+        id: "weak-key-review-j-f",
+        targetKeys: ["j", "f"],
+      },
+    });
+  });
+
+  it("returns undefined when no review prompt is available", () => {
+    expect(createWeakKeyReviewQuest({ save: createNewSave(new Date(), "normal") })).toBeUndefined();
+  });
+});

--- a/src/quest/review-quest.ts
+++ b/src/quest/review-quest.ts
@@ -1,0 +1,30 @@
+import { createTranslator, type LocaleId } from "../i18n/messages.js";
+import type { KeyQuestSave } from "../save/model.js";
+import type { PracticePrompt } from "../practice/session.js";
+import { createWeakKeyReviewPrompt } from "../practice/weak-key-review.js";
+
+export type WeakKeyReviewQuest = {
+  readonly id: "weak-key-review";
+  readonly title: string;
+  readonly prompt: PracticePrompt;
+  readonly targetKeys: readonly string[];
+  readonly advancesJourney: false;
+};
+
+export function createWeakKeyReviewQuest(options: {
+  readonly save: KeyQuestSave;
+  readonly locale?: LocaleId;
+}): WeakKeyReviewQuest | undefined {
+  const prompt = createWeakKeyReviewPrompt(options.save);
+  if (prompt === undefined) {
+    return undefined;
+  }
+
+  return {
+    id: "weak-key-review",
+    title: createTranslator(options.locale ?? options.save.settings.locale).t("review.lessonTitle"),
+    prompt,
+    targetKeys: prompt.targetKeys,
+    advancesJourney: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Wrap generated weak-key review prompts in typed quest metadata.
- Make review quest no-journey-advancement policy explicit.
- Update app review flow to use the quest boundary and sync progression docs.

## Test plan
- npm run verify

Closes #137

Made with [Cursor](https://cursor.com)