### PR TITLE
Add 90-day ending state and post-game goals

### DIFF
--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -160,7 +160,7 @@ Goal: make KeyQuest rewarding beyond the first month and after the ending.
 
 - Deterministic daily roguelite quest modifiers
 - First deterministic crafting-material equipment upgrade slice
-- Post-ending practice goals
+- First 90-day ending state and post-game goal model
 - Optional new-game-plus style progression
 - Importable lesson packs
 - Accessibility and localization polish

--- a/docs/PROGRESSION_DESIGN.md
+++ b/docs/PROGRESSION_DESIGN.md
@@ -101,6 +101,18 @@ The active modifier rotates by journey day:
 Modifiers change rewards, not the measured typing score. WPM, accuracy, and
 mistakes must remain honest training feedback.
 
+## Implemented Ending Slice
+
+The first ending implementation defines a stable Day 90 boundary:
+
+- Before Day 90, the journey reports remaining days.
+- On Day 90, the ending becomes ready for a future final scene.
+- After Day 90, post-game goals track a 7-day streak, 10 perfect sessions, and
+  25 Focus Crystals.
+
+This keeps the 90-day promise explicit while allowing the lesson curriculum and
+final story scene to be filled in later.
+
 ## Implemented Resource Slice
 
 The first resource implementation is intentionally small and deterministic:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -68,7 +68,8 @@
 
 - [x] Add roguelite quest modifiers.
 - [x] Add incremental equipment upgrades and crafting materials.
-- [ ] Add 90-day ending and post-game practice goals.
+- [x] Add 90-day ending state and post-game practice goal model.
+- [ ] Add final Day 90 ending scene content.
 - [ ] Add importable lesson packs.
 - [ ] Prepare npm publishing.
 - [ ] Add release notes and changelog automation.

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import {
   defaultScenes,
   practiceIntroScene,
   renderPracticeAchievements,
+  renderPracticeEndingProgress,
   renderPracticeJourneyProgress,
   renderPracticeReviewResult,
   renderPracticeRunResult,
@@ -235,6 +236,16 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   );
   if (journeyProgressLines.length > 0) {
     finalScreenSections.push(journeyProgressLines);
+  }
+  const endingProgressLines = renderPracticeEndingProgress(
+    {
+      beforeSave: menuSave,
+      afterSave: result.updatedSave,
+    },
+    translator,
+  );
+  if (endingProgressLines.length > 0) {
+    finalScreenSections.push(endingProgressLines);
   }
   screen.render(joinScreenSections(finalScreenSections));
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -106,6 +106,13 @@ const EN_MESSAGES = {
   "journey.riverGateClear": "Ferryman Trial cleared. The River Gate yields to your steady hands.",
   "journey.lanternKeepClear":
     "Beacon Trial cleared. The Lantern Keep shines over your number-row reach.",
+  "ending.heading": "Ending",
+  "ending.ready": "Day 90 complete. The final gate is open when the ending scene is ready.",
+  "postGame.heading": "Post-Game Goals",
+  "postGame.goalProgress": "{goal}: {current}/{target}",
+  "postGame.goal.sevenDayStreak": "Keep a 7-day streak",
+  "postGame.goal.perfectTen": "Complete 10 perfect sessions",
+  "postGame.goal.focusCrystalCache": "Gather 25 Focus Crystals",
 } as const;
 
 const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, string>>>>> = {
@@ -212,6 +219,13 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
       "Ferryman Trial クリア。River Gate はあなたの落ち着いた指に道を譲りました。",
     "journey.lanternKeepClear":
       "Beacon Trial クリア。Lantern Keep の灯があなたの数字段の到達を照らしています。",
+    "ending.heading": "エンディング",
+    "ending.ready": "Day 90 完了。エンディングシーンの準備が整えば最後の門が開きます。",
+    "postGame.heading": "クリア後の目標",
+    "postGame.goalProgress": "{goal}: {current}/{target}",
+    "postGame.goal.sevenDayStreak": "7日連続を維持する",
+    "postGame.goal.perfectTen": "ノーミスセッションを10回完了する",
+    "postGame.goal.focusCrystalCache": "Focus Crystal を25個集める",
   },
   "zh-CN": {
     ...EN_MESSAGES,
@@ -309,6 +323,13 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "journey.meadowRoadClear": "Waystone Trial 已通过。Meadow Road 通向更辽阔的土地。",
     "journey.riverGateClear": "Ferryman Trial 已通过。River Gate 为你稳定的双手让路。",
     "journey.lanternKeepClear": "Beacon Trial 已通过。Lantern Keep 照亮了你的数字行触达。",
+    "ending.heading": "结局",
+    "ending.ready": "Day 90 完成。结局场景准备好后，最后的门将会开启。",
+    "postGame.heading": "通关后目标",
+    "postGame.goalProgress": "{goal}: {current}/{target}",
+    "postGame.goal.sevenDayStreak": "保持 7 天连续练习",
+    "postGame.goal.perfectTen": "完成 10 次无错误练习",
+    "postGame.goal.focusCrystalCache": "收集 25 个 Focus Crystal",
   },
   ko: {
     ...EN_MESSAGES,
@@ -408,6 +429,13 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "journey.meadowRoadClear": "Waystone Trial 클리어. Meadow Road가 더 넓은 땅으로 이어집니다.",
     "journey.riverGateClear": "Ferryman Trial 클리어. River Gate가 차분한 손끝에 길을 내줍니다.",
     "journey.lanternKeepClear": "Beacon Trial 클리어. Lantern Keep의 빛이 숫자 행 도달을 비춥니다.",
+    "ending.heading": "엔딩",
+    "ending.ready": "Day 90 완료. 엔딩 장면이 준비되면 마지막 문이 열립니다.",
+    "postGame.heading": "클리어 후 목표",
+    "postGame.goalProgress": "{goal}: {current}/{target}",
+    "postGame.goal.sevenDayStreak": "7일 연속 기록 유지",
+    "postGame.goal.perfectTen": "무실수 세션 10회 완료",
+    "postGame.goal.focusCrystalCache": "Focus Crystal 25개 모으기",
   },
   es: {
     ...EN_MESSAGES,
@@ -510,6 +538,13 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "journey.riverGateClear": "Ferryman Trial superada. River Gate cede ante tus manos firmes.",
     "journey.lanternKeepClear":
       "Beacon Trial superada. Lantern Keep ilumina tu alcance en la fila numérica.",
+    "ending.heading": "Final",
+    "ending.ready": "Day 90 completado. La puerta final se abrirá cuando la escena esté lista.",
+    "postGame.heading": "Objetivos post-game",
+    "postGame.goalProgress": "{goal}: {current}/{target}",
+    "postGame.goal.sevenDayStreak": "Mantén una racha de 7 días",
+    "postGame.goal.perfectTen": "Completa 10 sesiones perfectas",
+    "postGame.goal.focusCrystalCache": "Reúne 25 Focus Crystals",
   },
   "pt-BR": {
     ...EN_MESSAGES,
@@ -612,6 +647,14 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "journey.riverGateClear": "Ferryman Trial concluída. River Gate cede às suas mãos firmes.",
     "journey.lanternKeepClear":
       "Beacon Trial concluída. Lantern Keep ilumina seu alcance na fileira numérica.",
+    "ending.heading": "Final",
+    "ending.ready":
+      "Day 90 concluído. O portão final abrirá quando a cena de final estiver pronta.",
+    "postGame.heading": "Objetivos pós-jogo",
+    "postGame.goalProgress": "{goal}: {current}/{target}",
+    "postGame.goal.sevenDayStreak": "Mantenha uma sequência de 7 dias",
+    "postGame.goal.perfectTen": "Complete 10 sessões perfeitas",
+    "postGame.goal.focusCrystalCache": "Junte 25 Focus Crystals",
   },
 };
 

--- a/src/quest/ending.test.ts
+++ b/src/quest/ending.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { createInitialQuestResources, createNewSave } from "../save/model.js";
+import { getJourneyEndingState, getPostGameGoals, JOURNEY_ENDING_DAY } from "./ending.js";
+
+describe("journey ending", () => {
+  it("reports remaining days before Day 90", () => {
+    const save = createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal");
+
+    expect(getJourneyEndingState(save)).toEqual({
+      status: "inProgress",
+      daysRemaining: JOURNEY_ENDING_DAY - 1,
+    });
+  });
+
+  it("marks Day 90 as ending ready", () => {
+    const save = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: JOURNEY_ENDING_DAY,
+        chapter: 12,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+
+    expect(getJourneyEndingState(save)).toEqual({
+      status: "endingReady",
+    });
+  });
+
+  it("builds deterministic post-game goals after the ending", () => {
+    const resources = createInitialQuestResources();
+    const save = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: JOURNEY_ENDING_DAY + 1,
+        chapter: 13,
+        storyFlag: "noviceHallStarted" as const,
+      },
+      progress: {
+        ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal").progress,
+        streakDays: 8,
+        resources: {
+          ...resources,
+          materials: {
+            ...resources.materials,
+            focusCrystal: 12,
+          },
+        },
+        sessions: [
+          {
+            id: "session-perfect",
+            mode: "normal" as const,
+            startedAt: "2026-01-01T00:00:00.000Z",
+            completedAt: "2026-01-01T00:10:00.000Z",
+            promptCount: 3,
+            accuracy: 1,
+            wordsPerMinute: 30,
+            xpGained: 50,
+            mistakes: [],
+          },
+        ],
+      },
+    };
+
+    expect(getJourneyEndingState(save).status).toBe("postGame");
+    expect(getPostGameGoals(save)).toEqual([
+      {
+        id: "sevenDayStreak",
+        current: 7,
+        target: 7,
+        completed: true,
+      },
+      {
+        id: "perfectTen",
+        current: 1,
+        target: 10,
+        completed: false,
+      },
+      {
+        id: "focusCrystalCache",
+        current: 12,
+        target: 25,
+        completed: false,
+      },
+    ]);
+  });
+});

--- a/src/quest/ending.ts
+++ b/src/quest/ending.ts
@@ -1,0 +1,65 @@
+import type { KeyQuestSave } from "../save/model.js";
+
+export const JOURNEY_ENDING_DAY = 90;
+
+export type PostGameGoalId = "sevenDayStreak" | "perfectTen" | "focusCrystalCache";
+
+export type PostGameGoal = {
+  readonly id: PostGameGoalId;
+  readonly current: number;
+  readonly target: number;
+  readonly completed: boolean;
+};
+
+export type JourneyEndingState =
+  | {
+      readonly status: "inProgress";
+      readonly daysRemaining: number;
+    }
+  | {
+      readonly status: "endingReady";
+    }
+  | {
+      readonly status: "postGame";
+      readonly goals: readonly PostGameGoal[];
+    };
+
+export function getJourneyEndingState(save: KeyQuestSave): JourneyEndingState {
+  if (save.journey.day < JOURNEY_ENDING_DAY) {
+    return {
+      status: "inProgress",
+      daysRemaining: JOURNEY_ENDING_DAY - save.journey.day,
+    };
+  }
+
+  if (save.journey.day === JOURNEY_ENDING_DAY) {
+    return {
+      status: "endingReady",
+    };
+  }
+
+  return {
+    status: "postGame",
+    goals: getPostGameGoals(save),
+  };
+}
+
+export function getPostGameGoals(save: KeyQuestSave): readonly PostGameGoal[] {
+  const perfectSessions = save.progress.sessions.filter((session) => session.accuracy === 1).length;
+  const focusCrystals = save.progress.resources?.materials.focusCrystal ?? 0;
+
+  return [
+    createGoal("sevenDayStreak", save.progress.streakDays, 7),
+    createGoal("perfectTen", perfectSessions, 10),
+    createGoal("focusCrystalCache", focusCrystals, 25),
+  ];
+}
+
+function createGoal(id: PostGameGoalId, current: number, target: number): PostGameGoal {
+  return {
+    id,
+    current: Math.min(current, target),
+    target,
+    completed: current >= target,
+  };
+}

--- a/src/scenes/scenes.test.ts
+++ b/src/scenes/scenes.test.ts
@@ -4,6 +4,7 @@ import { createTranslator } from "../i18n/messages.js";
 import { createInitialQuestResources, createNewSave } from "../save/model.js";
 import {
   renderPracticeAchievements,
+  renderPracticeEndingProgress,
   renderPracticeJourneyProgress,
   renderPracticeReviewResult,
   renderPracticeRewards,
@@ -287,5 +288,73 @@ describe("scene rendering", () => {
         createTranslator("en"),
       ),
     ).toEqual(["Journey", "Gatekeeper Trial cleared. The Novice Hall opens the road ahead."]);
+  });
+
+  it("renders the ending ready message when the journey reaches Day 90", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 89,
+        chapter: 12,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+    const afterSave = {
+      ...beforeSave,
+      journey: {
+        ...beforeSave.journey,
+        day: 90,
+      },
+    };
+
+    expect(
+      renderPracticeEndingProgress(
+        {
+          beforeSave,
+          afterSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual([
+      "Ending",
+      "Day 90 complete. The final gate is open when the ending scene is ready.",
+    ]);
+  });
+
+  it("renders post-game goal progress", () => {
+    const beforeSave = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 90,
+        chapter: 12,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+    const afterSave = {
+      ...beforeSave,
+      journey: {
+        ...beforeSave.journey,
+        day: 91,
+      },
+      progress: {
+        ...beforeSave.progress,
+        streakDays: 3,
+      },
+    };
+
+    expect(
+      renderPracticeEndingProgress(
+        {
+          beforeSave,
+          afterSave,
+        },
+        createTranslator("en"),
+      ),
+    ).toEqual([
+      "Post-Game Goals",
+      "Keep a 7-day streak: 3/7",
+      "Complete 10 perfect sessions: 0/10",
+      "Gather 25 Focus Crystals: 0/25",
+    ]);
   });
 });

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -1,5 +1,6 @@
 import type {
   PracticeAchievementsView,
+  PracticeEndingProgressView,
   PracticeJourneyProgressView,
   PracticeReviewResultView,
   PracticeRewardsView,
@@ -18,6 +19,7 @@ import {
   RIVER_GATE_FINAL_DAY,
 } from "../lessons/manifest.js";
 import { EQUIPMENT_UPGRADES, getEquipmentUpgradeLevel } from "../quest/equipment.js";
+import { getJourneyEndingState } from "../quest/ending.js";
 import { getQuestArcForDay } from "../quest/map.js";
 import { getQuestModifierForDay } from "../quest/modifiers.js";
 import { createInitialQuestResources } from "../save/model.js";
@@ -343,6 +345,32 @@ export function renderPracticeJourneyProgress(
   }
 
   return [t("journey.heading"), ...progressLines];
+}
+
+export function renderPracticeEndingProgress(
+  progress: PracticeEndingProgressView,
+  translator: SceneContext["translator"],
+): readonly string[] {
+  const beforeState = getJourneyEndingState(progress.beforeSave);
+  const afterState = getJourneyEndingState(progress.afterSave);
+  if (afterState.status === "inProgress") {
+    return [];
+  }
+
+  const { t } = translator;
+  if (afterState.status === "endingReady") {
+    return beforeState.status === "endingReady" ? [] : [t("ending.heading"), t("ending.ready")];
+  }
+
+  const goalLines = afterState.goals.map((goal) =>
+    t("postGame.goalProgress", {
+      goal: t(`postGame.goal.${goal.id}`),
+      current: goal.current,
+      target: goal.target,
+    }),
+  );
+
+  return [t("postGame.heading"), ...goalLines];
 }
 
 function formatElapsedSeconds(elapsedSeconds: number): string {

--- a/src/scenes/types.ts
+++ b/src/scenes/types.ts
@@ -71,3 +71,8 @@ export type PracticeJourneyProgressView = {
   readonly beforeSave: KeyQuestSave;
   readonly afterSave: KeyQuestSave;
 };
+
+export type PracticeEndingProgressView = {
+  readonly beforeSave: KeyQuestSave;
+  readonly afterSave: KeyQuestSave;
+};


### PR DESCRIPTION
## Summary
- Add a typed Day 90 ending boundary and post-game goal model.
- Render ending-ready and post-game goal sections in the practice result flow.
- Document the ending boundary while keeping final story scene content as a follow-up.

## Test plan
- [x] npm run verify

Closes #145

Made with [Cursor](https://cursor.com)