### PR TITLE
Add importable lesson pack support

### DIFF
--- a/docs/LESSON_PACKS.md
+++ b/docs/LESSON_PACKS.md
@@ -1,0 +1,41 @@
+# Lesson Packs
+
+## Goal
+
+Lesson packs let external lesson collections plug into KeyQuest without editing
+the bundled lesson manifest.
+
+Typing prompts remain English. Pack metadata can be local to the pack, while the
+core UI continues to use the selected KeyQuest locale.
+
+## Manifest
+
+Create a `keyquest-pack.json` file:
+
+```json
+{
+  "version": 1,
+  "id": "home-row-extra",
+  "title": "Home Row Extra",
+  "lessons": [
+    {
+      "day": 1,
+      "path": "lessons/day-1.json"
+    }
+  ]
+}
+```
+
+Lesson paths are resolved relative to the manifest file. Each lesson file uses
+the normal KeyQuest lesson schema.
+
+## Running
+
+Use `--lesson-pack` to select a pack for journey-based lesson lookup:
+
+```sh
+npm run dev -- --lesson-pack ./packs/home-row-extra/keyquest-pack.json
+```
+
+`--lesson` still has priority for one-off lesson debugging. With no lesson flags,
+KeyQuest uses the bundled lesson manifest.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -162,7 +162,7 @@ Goal: make KeyQuest rewarding beyond the first month and after the ending.
 - First deterministic crafting-material equipment upgrade slice
 - First 90-day ending state and post-game goal model
 - Optional new-game-plus style progression
-- Importable lesson packs
+- Importable lesson pack manifests via `--lesson-pack`
 - Accessibility and localization polish
 
 ## Release: Public CLI

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -70,6 +70,6 @@
 - [x] Add incremental equipment upgrades and crafting materials.
 - [x] Add 90-day ending state and post-game practice goal model.
 - [ ] Add final Day 90 ending scene content.
-- [ ] Add importable lesson packs.
+- [x] Add importable lesson packs.
 - [ ] Prepare npm publishing.
 - [ ] Add release notes and changelog automation.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -196,6 +196,56 @@ describe("runApp", () => {
 
     expect(output.text()).toContain("Segment 4/4");
     expect(output.text()).toContain("Prompts: 4");
+  });
+
+  it("loads the current day lesson from an imported lesson pack", async () => {
+    const packDirectory = await createTempDirectory();
+    const lessonsDirectory = join(packDirectory, "lessons");
+    await mkdir(lessonsDirectory);
+    const lesson = {
+      ...createTestLesson(),
+      id: "pack-day-1",
+      title: "Pack Day 1",
+      prompts: createTestLesson().prompts.map((prompt, index) => ({
+        ...prompt,
+        id: `pack-prompt-${index + 1}`,
+        text: ["aa", "ss", "dd"][index] ?? prompt.text,
+      })),
+    };
+    await writeFile(join(lessonsDirectory, "day-1.json"), JSON.stringify(lesson), "utf8");
+    const manifestPath = join(packDirectory, "keyquest-pack.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        version: 1,
+        id: "test-pack",
+        title: "Test Pack",
+        lessons: [
+          {
+            day: 1,
+            path: "lessons/day-1.json",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const output = createMemoryOutput();
+
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["1", "aa", "ss", "dd"]),
+      textOutput: output,
+      lesson: undefined,
+      lessonPath: undefined,
+      lessonPackPath: manifestPath,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("Lesson: Pack Day 1");
+    expect(output.text()).toContain("Type: aa");
+    expect(output.text()).toContain("Session Result");
   });
 
   it("shows streak milestone messages after rewards", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import {
   loadLessonFromFile,
   selectPracticePrompts,
 } from "./lessons/loader.js";
+import { getLessonPackLessonPath, loadLessonPackManifest } from "./lessons/pack.js";
 import type { Lesson } from "./lessons/schema.js";
 import {
   createMenuTranslator,
@@ -52,6 +53,7 @@ export type RunAppOptions = {
   readonly textOutput: TextOutput;
   readonly lesson: Lesson | undefined;
   readonly lessonPath: string | undefined;
+  readonly lessonPackPath?: string;
   readonly terminalRuntime?: TerminalRuntime;
   readonly realtimeInput?: RealtimeTypingInput;
   readonly now?: Date;
@@ -89,10 +91,14 @@ export async function runApp(options: RunAppOptions): Promise<void> {
   const menuSave = menuSelection.save;
   const reviewQuest =
     menuSelection.action === "review" ? createWeakKeyReviewQuest({ save: menuSave }) : undefined;
-  const defaultLessonPath = getDefaultLessonPathForDay(menuSave.journey.day);
+  const resolvedLessonPath = await resolveLessonPath({
+    day: menuSave.journey.day,
+    lessonPath: options.lessonPath,
+    lessonPackPath: options.lessonPackPath,
+  });
   const lesson =
     reviewQuest === undefined
-      ? (options.lesson ?? (await loadLessonFromFile(options.lessonPath ?? defaultLessonPath)))
+      ? (options.lesson ?? (await loadLessonFromFile(resolvedLessonPath)))
       : createReviewLesson(menuSave.journey.day, reviewQuest.title, reviewQuest.prompt);
   const practicePrompts =
     reviewQuest === undefined
@@ -378,6 +384,23 @@ async function runLanguageOptions(options: {
   ]);
 
   return selectedLocale;
+}
+
+async function resolveLessonPath(options: {
+  readonly day: number;
+  readonly lessonPath: string | undefined;
+  readonly lessonPackPath: string | undefined;
+}): Promise<string> {
+  if (options.lessonPath !== undefined) {
+    return options.lessonPath;
+  }
+
+  if (options.lessonPackPath !== undefined) {
+    const manifest = await loadLessonPackManifest(options.lessonPackPath);
+    return getLessonPackLessonPath(manifest, options.lessonPackPath, options.day);
+  }
+
+  return getDefaultLessonPathForDay(options.day);
 }
 
 function renderTerminalWarnings(

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -18,6 +18,15 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--lesson=lessons/day-1.json"]).lessonPath).toBe("lessons/day-1.json");
   });
 
+  it("parses lesson pack manifest path forms", () => {
+    expect(
+      parseCliArgs(["--lesson-pack", "packs/home-row/keyquest-pack.json"]).lessonPackPath,
+    ).toBe("packs/home-row/keyquest-pack.json");
+    expect(parseCliArgs(["--lesson-pack=packs/home-row/keyquest-pack.json"]).lessonPackPath).toBe(
+      "packs/home-row/keyquest-pack.json",
+    );
+  });
+
   it("parses terminal runtime flags", () => {
     expect(parseCliArgs(["--color", "always"]).colorMode).toBe("always");
     expect(parseCliArgs(["--color=never"]).colorMode).toBe("never");

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,6 +4,7 @@ export type CliOptions = {
   readonly devMode: boolean;
   readonly saveDirectory: string | undefined;
   readonly lessonPath: string | undefined;
+  readonly lessonPackPath: string | undefined;
   readonly colorMode: TerminalColorMode | undefined;
   readonly reducedMotion: boolean;
 };
@@ -12,6 +13,7 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
   let devMode = false;
   let saveDirectory: string | undefined;
   let lessonPath: string | undefined;
+  let lessonPackPath: string | undefined;
   let colorMode: TerminalColorMode | undefined;
   let reducedMotion = false;
 
@@ -68,6 +70,22 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
       continue;
     }
 
+    if (arg === "--lesson-pack") {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--lesson-pack requires a manifest file path");
+      }
+
+      lessonPackPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--lesson-pack=")) {
+      lessonPackPath = arg.slice("--lesson-pack=".length);
+      continue;
+    }
+
     if (arg === "--color") {
       const value = args[index + 1];
       if (value === undefined || value.startsWith("-")) {
@@ -87,5 +105,5 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
     throw new Error(`Unknown option: ${arg}`);
   }
 
-  return { devMode, saveDirectory, lessonPath, colorMode, reducedMotion };
+  return { devMode, saveDirectory, lessonPath, lessonPackPath, colorMode, reducedMotion };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ try {
       saveDirectory: options.saveDirectory,
       lesson: undefined,
       lessonPath: options.lessonPath,
+      ...(options.lessonPackPath === undefined ? {} : { lessonPackPath: options.lessonPackPath }),
       terminalRuntime,
       realtimeInput,
       textInput,

--- a/src/lessons/pack.test.ts
+++ b/src/lessons/pack.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getLessonPackLessonPath,
+  loadLessonPackManifest,
+  validateLessonPackManifest,
+} from "./pack.js";
+
+describe("lesson packs", () => {
+  it("validates lesson pack manifests", () => {
+    expect(
+      validateLessonPackManifest({
+        version: 1,
+        id: "home-row-pack",
+        title: "Home Row Pack",
+        lessons: [
+          {
+            day: 1,
+            path: "day-1.json",
+          },
+        ],
+      }),
+    ).toEqual({
+      version: 1,
+      id: "home-row-pack",
+      title: "Home Row Pack",
+      lessons: [
+        {
+          day: 1,
+          path: "day-1.json",
+        },
+      ],
+    });
+  });
+
+  it("loads manifests and resolves lesson paths relative to the manifest", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "keyquest-pack-"));
+    const manifestPath = join(directory, "keyquest-pack.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        version: 1,
+        id: "custom-pack",
+        title: "Custom Pack",
+        lessons: [
+          {
+            day: 2,
+            path: "lessons/day-2.json",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const manifest = await loadLessonPackManifest(manifestPath);
+
+    expect(getLessonPackLessonPath(manifest, manifestPath, 2)).toBe(
+      join(directory, "lessons/day-2.json"),
+    );
+  });
+
+  it("rejects missing days", () => {
+    const manifest = validateLessonPackManifest({
+      version: 1,
+      id: "custom-pack",
+      title: "Custom Pack",
+      lessons: [
+        {
+          day: 1,
+          path: "day-1.json",
+        },
+      ],
+    });
+
+    expect(() => getLessonPackLessonPath(manifest, "/packs/keyquest-pack.json", 2)).toThrow(
+      "does not include day 2",
+    );
+  });
+});

--- a/src/lessons/pack.ts
+++ b/src/lessons/pack.ts
@@ -1,0 +1,84 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+export type LessonPackManifestEntry = {
+  readonly day: number;
+  readonly path: string;
+};
+
+export type LessonPackManifest = {
+  readonly version: 1;
+  readonly id: string;
+  readonly title: string;
+  readonly lessons: readonly LessonPackManifestEntry[];
+};
+
+export async function loadLessonPackManifest(path: string): Promise<LessonPackManifest> {
+  const content = await readFile(path, "utf8");
+  return validateLessonPackManifest(JSON.parse(content) as unknown);
+}
+
+export function getLessonPackLessonPath(
+  manifest: LessonPackManifest,
+  manifestPath: string,
+  day: number,
+): string {
+  if (!Number.isInteger(day) || day < 1) {
+    throw new Error(`Lesson pack day must be a positive integer: ${day}`);
+  }
+
+  const entry = manifest.lessons.find((lesson) => lesson.day === day);
+  if (entry === undefined) {
+    throw new Error(`Lesson pack ${manifest.id} does not include day ${day}`);
+  }
+
+  return resolve(dirname(manifestPath), entry.path);
+}
+
+export function validateLessonPackManifest(value: unknown): LessonPackManifest {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Lesson pack manifest must be an object");
+  }
+
+  const manifest = value as Partial<LessonPackManifest>;
+  if (manifest.version !== 1) {
+    throw new Error("Lesson pack manifest version must be 1");
+  }
+  if (typeof manifest.id !== "string" || manifest.id.length === 0) {
+    throw new Error("Lesson pack manifest requires an id");
+  }
+  if (typeof manifest.title !== "string" || manifest.title.length === 0) {
+    throw new Error("Lesson pack manifest requires a title");
+  }
+  if (!Array.isArray(manifest.lessons) || manifest.lessons.length === 0) {
+    throw new Error("Lesson pack manifest requires at least one lesson");
+  }
+
+  return {
+    version: 1,
+    id: manifest.id,
+    title: manifest.title,
+    lessons: manifest.lessons.map(validateLessonPackManifestEntry),
+  };
+}
+
+function validateLessonPackManifestEntry(value: unknown): LessonPackManifestEntry {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Lesson pack lesson entries must be objects");
+  }
+
+  const entry = value as Partial<LessonPackManifestEntry>;
+  const day = entry.day;
+  const path = entry.path;
+  if (typeof day !== "number" || !Number.isInteger(day) || day < 1) {
+    throw new Error("Lesson pack lesson entries require a positive integer day");
+  }
+  if (typeof path !== "string" || path.length === 0) {
+    throw new Error("Lesson pack lesson entries require a path");
+  }
+
+  return {
+    day,
+    path,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `--lesson-pack` support for external `keyquest-pack.json` manifests.
- Resolve pack lesson paths by journey day while preserving `--lesson` priority and bundled fallback behavior.
- Document the manifest format and add unit/integration coverage.

## Test plan
- [x] npm run verify

Closes #147

Made with [Cursor](https://cursor.com)