### PR TITLE
Prepare npm publishing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 A terminal typing adventure game for fun and effective practice.
 
+## Usage
+
+Run locally from the repository:
+
+```bash
+npm run dev
+```
+
+After the package is published, the intended quick start is:
+
+```bash
+npx keyquest
+```
+
+Useful CLI flags:
+
+```bash
+keyquest --dev
+keyquest --lesson ./lessons/novice-hall-day-1.json
+keyquest --lesson-pack ./packs/home-row-extra/keyquest-pack.json
+keyquest --no-color
+keyquest --reduced-motion
+```
+
 ## Vision
 
 KeyQuest is a terminal-first typing adventure game. It should make daily typing
@@ -39,6 +63,12 @@ Run the full local verification suite:
 npm run verify
 ```
 
+Check the package contents before publishing:
+
+```bash
+npm run package:smoke
+```
+
 ## Project Management
 
 This project is managed with GitHub Issues and local Markdown planning docs.
@@ -47,6 +77,7 @@ This project is managed with GitHub Issues and local Markdown planning docs.
 - Roadmap: `docs/ROADMAP.md`
 - Milestones: `docs/MILESTONES.md`
 - Active TODOs: `docs/TODO.md`
+- Lesson packs: `docs/LESSON_PACKS.md`
 - Onboarding training: `docs/ONBOARDING_TRAINING.md`
 - UI specification: `docs/UI_SPEC.md`
 - Progression design: `docs/PROGRESSION_DESIGN.md`

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -172,6 +172,7 @@ Goal: publish a useful open-source CLI.
 - `npx keyquest` smoke test
 - README with screenshots or terminal recording
 - npm package metadata
+- npm package smoke script and publishing checklist
 - Supported locales validated
 - Release checklist and changelog
 - First public release notes

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,39 @@
+# Publishing
+
+## Goal
+
+KeyQuest should be easy to try with `npx keyquest` once the first public release
+is ready.
+
+## Package Checks
+
+Before publishing:
+
+```sh
+npm run verify
+npm run package:smoke
+```
+
+`package:smoke` builds `dist/` and runs `npm pack --dry-run` so the package
+contents can be inspected without publishing.
+
+## Package Boundaries
+
+The npm package includes:
+
+- `dist/`: compiled CLI entrypoint and runtime modules.
+- `lessons/`: bundled English typing lessons.
+- `README.md`: quick start and project overview.
+- `LICENSE`: license text.
+
+Development-only sources, tests, docs, and local save data should stay out of the
+published package unless they become part of the public user experience.
+
+## Release Steps
+
+1. Confirm `main` is green and synced with `origin/main`.
+2. Update release notes and package version.
+3. Run `npm run verify`.
+4. Run `npm run package:smoke` and inspect the file list.
+5. Publish with npm using the intended access level.
+6. Create a GitHub release that links the changelog entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -71,5 +71,5 @@
 - [x] Add 90-day ending state and post-game practice goal model.
 - [ ] Add final Day 90 ending scene content.
 - [x] Add importable lesson packs.
-- [ ] Prepare npm publishing.
+- [x] Prepare npm publishing.
 - [ ] Add release notes and changelog automation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "keyquest",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keyquest",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "keyquest": "dist/index.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@types/node": "^25.6.0",
@@ -17,6 +20,10 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "description": "A terminal typing adventure game for fun and effective practice.",
   "type": "module",
+  "engines": {
+    "node": ">=20",
+    "npm": ">=10"
+  },
   "bin": {
     "keyquest": "./dist/index.js"
   },
@@ -23,7 +27,9 @@
     "lessons:validate": "tsx src/lessons/validate-bundled.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test"
+    "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test",
+    "package:smoke": "npm run build && npm pack --dry-run",
+    "prepublishOnly": "npm run verify && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add package engines, package smoke script, and prepublish verification/build hook.
- Document package boundaries and release steps.
- Expand README usage with intended `npx keyquest` flow and CLI flags.

## Test plan
- [x] npm run verify
- [x] npm run package:smoke

Closes #149

Made with [Cursor](https://cursor.com)