### PR TITLE
Add release notes automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to KeyQuest will be documented here.
+
+This project uses a lightweight manual changelog plus generated release-note
+drafts from git history.
+
+## Unreleased
+
+- Added `npm run release:notes` to draft release notes from commits since the
+  latest tag.
+- Added publishing docs that connect changelog updates, package smoke checks, and
+  GitHub releases.
+
+## Release Workflow
+
+Before a release, run:
+
+```sh
+npm run release:notes
+```
+
+Use the draft to update this changelog, then link the final changelog section
+from the GitHub release.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This project is managed with GitHub Issues and local Markdown planning docs.
 - Achievements: `docs/ACHIEVEMENTS.md`
 - Localization: `docs/LOCALIZATION.md`
 - Save data: `docs/SAVE_DATA.md`
+- Publishing: `docs/PUBLISHING.md`
 - Testing strategy: `docs/TESTING_STRATEGY.md`
 - Development philosophy and policy: `docs/DEVELOPMENT.md`
 - Coding standards: `docs/CODING_STANDARDS.md`

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -174,5 +174,5 @@ Goal: publish a useful open-source CLI.
 - npm package metadata
 - npm package smoke script and publishing checklist
 - Supported locales validated
-- Release checklist and changelog
+- Release notes script and changelog workflow
 - First public release notes

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -11,11 +11,14 @@ Before publishing:
 
 ```sh
 npm run verify
+npm run release:notes
 npm run package:smoke
 ```
 
 `package:smoke` builds `dist/` and runs `npm pack --dry-run` so the package
 contents can be inspected without publishing.
+`release:notes` prints a draft from git history so `CHANGELOG.md` and the GitHub
+release can stay aligned.
 
 ## Package Boundaries
 
@@ -32,8 +35,10 @@ published package unless they become part of the public user experience.
 ## Release Steps
 
 1. Confirm `main` is green and synced with `origin/main`.
-2. Update release notes and package version.
-3. Run `npm run verify`.
-4. Run `npm run package:smoke` and inspect the file list.
-5. Publish with npm using the intended access level.
-6. Create a GitHub release that links the changelog entry.
+2. Update package version.
+3. Run `npm run release:notes`.
+4. Update `CHANGELOG.md` from the generated draft.
+5. Run `npm run verify`.
+6. Run `npm run package:smoke` and inspect the file list.
+7. Publish with npm using the intended access level.
+8. Create a GitHub release that links the changelog entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -72,4 +72,4 @@
 - [ ] Add final Day 90 ending scene content.
 - [x] Add importable lesson packs.
 - [x] Prepare npm publishing.
-- [ ] Add release notes and changelog automation.
+- [x] Add release notes and changelog automation.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,14 @@ export default tseslint.config(
     ignores: ["dist/**", "coverage/**", "node_modules/**"],
   },
   js.configs.recommended,
+  {
+    files: ["**/*.js", "**/*.mjs"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+      },
+    },
+  },
   ...tseslint.configs.recommended,
   {
     files: ["**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test",
+    "release:notes": "node scripts/release-notes.mjs",
     "package:smoke": "npm run build && npm pack --dry-run",
     "prepublishOnly": "npm run verify && npm run build"
   },

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const version = typeof packageJson.version === "string" ? packageJson.version : "0.0.0";
+const today = new Date().toISOString().slice(0, 10);
+const latestTag = getLatestTag();
+const range = latestTag === undefined ? "HEAD" : `${latestTag}..HEAD`;
+const commits = getCommitSubjects(range).filter((commit) => !commit.subject.startsWith("Merge "));
+const sections = groupCommits(commits);
+
+console.log(`# Release Notes: v${version}`);
+console.log("");
+console.log(`Date: ${today}`);
+if (latestTag !== undefined) {
+  console.log(`Range: ${latestTag}..HEAD`);
+}
+console.log("");
+printSection("Added", sections.added);
+printSection("Fixed", sections.fixed);
+printSection("Changed", sections.changed);
+
+function getLatestTag() {
+  try {
+    return execFileSync("git", ["describe", "--tags", "--abbrev=0"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function getCommitSubjects(range) {
+  const output = execFileSync("git", ["log", "--pretty=format:%s%x09%h", range], {
+    encoding: "utf8",
+  }).trim();
+
+  if (output.length === 0) {
+    return [];
+  }
+
+  return output.split("\n").map((line) => {
+    const [subject = "", hash = ""] = line.split("\t");
+    return { subject, hash };
+  });
+}
+
+function groupCommits(commits) {
+  return commits.reduce(
+    (groups, commit) => {
+      if (/^(fix|resolve|repair)\b/i.test(commit.subject)) {
+        groups.fixed.push(commit);
+        return groups;
+      }
+
+      if (/^(add|introduce|create)\b/i.test(commit.subject)) {
+        groups.added.push(commit);
+        return groups;
+      }
+
+      groups.changed.push(commit);
+      return groups;
+    },
+    {
+      added: [],
+      fixed: [],
+      changed: [],
+    },
+  );
+}
+
+function printSection(title, commits) {
+  console.log(`## ${title}`);
+  console.log("");
+  if (commits.length === 0) {
+    console.log("- No changes.");
+    console.log("");
+    return;
+  }
+
+  for (const commit of commits) {
+    console.log(`- ${commit.subject} (${commit.hash})`);
+  }
+  console.log("");
+}


### PR DESCRIPTION
## Summary
- Add `npm run release:notes` for dependency-free release note drafts from git history.
- Add `CHANGELOG.md` and wire release notes into publishing docs.
- Adjust ESLint globals for local `.mjs` scripts.

## Test plan
- [x] npm run release:notes
- [x] npm run verify

Closes #151

Made with [Cursor](https://cursor.com)