### PR TITLE
Add CLI help and version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ drafts from git history.
 
 ## Unreleased
 
+- Added `--help` and `--version` CLI output for non-interactive discovery.
 - Added final Day 90 ending scene copy for the main journey completion state.
 - Added `npm run release:notes` to draft release notes from commits since the
   latest tag.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Useful CLI flags:
 
 ```bash
 keyquest --dev
+keyquest --help
+keyquest --version
 keyquest --lesson ./lessons/novice-hall-day-1.json
 keyquest --lesson-pack ./packs/home-row-extra/keyquest-pack.json
 keyquest --no-color

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -171,6 +171,7 @@ Goal: make KeyQuest rewarding beyond the first month and after the ending.
 Goal: publish a useful open-source CLI.
 
 - `npx keyquest` smoke test
+- CLI help and version output
 - README with screenshots or terminal recording
 - npm package metadata
 - npm package smoke script and publishing checklist

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -73,3 +73,7 @@
 - [x] Add importable lesson packs.
 - [x] Prepare npm publishing.
 - [x] Add release notes and changelog automation.
+
+## Release Readiness
+
+- [x] Add CLI help and version output.

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { parseCliArgs } from "./args.js";
 
 describe("parseCliArgs", () => {
+  it("defaults to running the game", () => {
+    expect(parseCliArgs([]).action).toBe("run");
+  });
+
+  it("parses non-interactive help and version actions", () => {
+    expect(parseCliArgs(["--help"]).action).toBe("help");
+    expect(parseCliArgs(["-h"]).action).toBe("help");
+    expect(parseCliArgs(["--version"]).action).toBe("version");
+    expect(parseCliArgs(["-v"]).action).toBe("version");
+  });
+
   it("parses development mode aliases", () => {
     expect(parseCliArgs(["--dev"]).devMode).toBe(true);
     expect(parseCliArgs(["-dev"]).devMode).toBe(true);

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,6 +1,7 @@
 import { parseTerminalColorMode, type TerminalColorMode } from "../terminal/runtime.js";
 
 export type CliOptions = {
+  readonly action: "run" | "help" | "version";
   readonly devMode: boolean;
   readonly saveDirectory: string | undefined;
   readonly lessonPath: string | undefined;
@@ -10,6 +11,7 @@ export type CliOptions = {
 };
 
 export function parseCliArgs(args: readonly string[]): CliOptions {
+  let action: CliOptions["action"] = "run";
   let devMode = false;
   let saveDirectory: string | undefined;
   let lessonPath: string | undefined;
@@ -25,6 +27,16 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
 
     if (arg === "--dev" || arg === "-dev") {
       devMode = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      action = "help";
+      continue;
+    }
+
+    if (arg === "--version" || arg === "-v") {
+      action = "version";
       continue;
     }
 
@@ -105,5 +117,13 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
     throw new Error(`Unknown option: ${arg}`);
   }
 
-  return { devMode, saveDirectory, lessonPath, lessonPackPath, colorMode, reducedMotion };
+  return {
+    action,
+    devMode,
+    saveDirectory,
+    lessonPath,
+    lessonPackPath,
+    colorMode,
+    reducedMotion,
+  };
 }

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { renderCliHelp, renderCliVersion } from "./help.js";
+
+describe("CLI help", () => {
+  it("renders usage and public options", () => {
+    const help = renderCliHelp();
+
+    expect(help).toContain("Usage:");
+    expect(help).toContain("keyquest [options]");
+    expect(help).toContain("--lesson-pack <path>");
+    expect(help).toContain("--reduced-motion");
+  });
+
+  it("renders the package version", () => {
+    expect(renderCliVersion("0.1.0")).toBe("keyquest 0.1.0");
+  });
+});

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,29 @@
+export function renderCliHelp(): string {
+  return [
+    "KeyQuest",
+    "",
+    "Usage:",
+    "  keyquest [options]",
+    "",
+    "Options:",
+    "  --help, -h                 Show this help message.",
+    "  --version, -v              Show the package version.",
+    "  --dev, -dev                Use readable development-mode save data.",
+    "  --save-dir <path>          Store saves in a custom directory.",
+    "  --lesson <path>            Run a single lesson file.",
+    "  --lesson-pack <path>       Resolve journey lessons from a pack manifest.",
+    "  --color <mode>             Use auto, always, or never.",
+    "  --no-color                 Disable ANSI color.",
+    "  --reduced-motion           Reduce terminal motion effects.",
+    "",
+    "Examples:",
+    "  keyquest",
+    "  keyquest --dev",
+    "  keyquest --lesson ./lessons/novice-hall-day-1.json",
+    "  keyquest --lesson-pack ./packs/home-row-extra/keyquest-pack.json",
+  ].join("\n");
+}
+
+export function renderCliVersion(version: string): string {
+  return `keyquest ${version}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+
 import { runApp } from "./app.js";
 import { parseCliArgs } from "./cli/args.js";
+import { renderCliHelp, renderCliVersion } from "./cli/help.js";
 import { createNodeTextInput } from "./cli/text-input.js";
 import { createNodeTextOutput } from "./cli/text-output.js";
 import { createNodeRealtimeTypingInput } from "./realtime/input.js";
@@ -9,38 +13,53 @@ import { resolveTerminalRuntime } from "./terminal/runtime.js";
 
 try {
   const options = parseCliArgs(process.argv.slice(2));
-  const textInput = createNodeTextInput({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  const textOutput = createNodeTextOutput(process.stdout);
-  const realtimeInput = createNodeRealtimeTypingInput(process.stdin);
-  const terminalRuntime = resolveTerminalRuntime({
-    colorMode: options.colorMode,
-    theme: undefined,
-    reducedMotion: options.reducedMotion,
-    columns: process.stdout.columns,
-    rows: process.stdout.rows,
-    isTty: process.stdout.isTTY === true,
-    env: process.env,
-  });
-  try {
-    await runApp({
-      mode: options.devMode ? "development" : "normal",
-      saveDirectory: options.saveDirectory,
-      lesson: undefined,
-      lessonPath: options.lessonPath,
-      ...(options.lessonPackPath === undefined ? {} : { lessonPackPath: options.lessonPackPath }),
-      terminalRuntime,
-      realtimeInput,
-      textInput,
-      textOutput,
+  if (options.action === "help") {
+    console.log(renderCliHelp());
+    process.exitCode = 0;
+  } else if (options.action === "version") {
+    console.log(renderCliVersion(readPackageVersion()));
+    process.exitCode = 0;
+  } else {
+    const textInput = createNodeTextInput({
+      input: process.stdin,
+      output: process.stdout,
     });
-  } finally {
-    textInput.close();
+    const textOutput = createNodeTextOutput(process.stdout);
+    const realtimeInput = createNodeRealtimeTypingInput(process.stdin);
+    const terminalRuntime = resolveTerminalRuntime({
+      colorMode: options.colorMode,
+      theme: undefined,
+      reducedMotion: options.reducedMotion,
+      columns: process.stdout.columns,
+      rows: process.stdout.rows,
+      isTty: process.stdout.isTTY === true,
+      env: process.env,
+    });
+    try {
+      await runApp({
+        mode: options.devMode ? "development" : "normal",
+        saveDirectory: options.saveDirectory,
+        lesson: undefined,
+        lessonPath: options.lessonPath,
+        ...(options.lessonPackPath === undefined ? {} : { lessonPackPath: options.lessonPackPath }),
+        terminalRuntime,
+        realtimeInput,
+        textInput,
+        textOutput,
+      });
+    } finally {
+      textInput.close();
+    }
   }
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`KeyQuest failed: ${message}`);
   process.exitCode = 1;
+}
+
+function readPackageVersion(): string {
+  const content = readFileSync(new URL("../package.json", import.meta.url), "utf8");
+  const packageJson = JSON.parse(content) as { readonly version?: unknown };
+
+  return typeof packageJson.version === "string" ? packageJson.version : "0.0.0";
 }


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` and `--version` / `-v` non-interactive CLI actions.
- Add reusable help/version renderers with parser tests.
- Document the flags in README and release-readiness tracking.

## Test plan
- [x] npm run verify
- [x] npm run build
- [x] node dist/index.js --help
- [x] node dist/index.js --version

Closes #155

Made with [Cursor](https://cursor.com)