### PR TITLE
Strengthen package smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ drafts from git history.
 
 ## Unreleased
 
+- Strengthened `npm run package:smoke` to install the packed tarball and run the CLI.
 - Added an in-game Help screen from the title menu.
 - Added `--help` and `--version` CLI output for non-interactive discovery.
 - Added final Day 90 ending scene copy for the main journey completion state.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -176,6 +176,7 @@ Goal: publish a useful open-source CLI.
 - README with screenshots or terminal recording
 - npm package metadata
 - npm package smoke script and publishing checklist
+- Tarball install smoke for packaged CLI
 - Supported locales validated
 - Release notes script and changelog workflow
 - First public release notes

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -15,8 +15,9 @@ npm run release:notes
 npm run package:smoke
 ```
 
-`package:smoke` builds `dist/` and runs `npm pack --dry-run` so the package
-contents can be inspected without publishing.
+`package:smoke` builds `dist/`, creates a local npm tarball, installs it into a
+temporary directory, and runs `keyquest --version` plus `keyquest --help` from the
+installed package.
 `release:notes` prints a draft from git history so `CHANGELOG.md` and the GitHub
 release can stay aligned.
 
@@ -39,6 +40,6 @@ published package unless they become part of the public user experience.
 3. Run `npm run release:notes`.
 4. Update `CHANGELOG.md` from the generated draft.
 5. Run `npm run verify`.
-6. Run `npm run package:smoke` and inspect the file list.
+6. Run `npm run package:smoke` and confirm the installed CLI smoke passes.
 7. Publish with npm using the intended access level.
 8. Create a GitHub release that links the changelog entry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -78,3 +78,4 @@
 
 - [x] Add CLI help and version output.
 - [x] Add in-game help menu.
+- [x] Strengthen npm package tarball smoke test.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:watch": "vitest",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test",
     "release:notes": "node scripts/release-notes.mjs",
-    "package:smoke": "npm run build && npm pack --dry-run",
+    "package:smoke": "node scripts/package-smoke.mjs",
     "prepublishOnly": "npm run verify && npm run build"
   },
   "repository": {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { URL } from "node:url";
+
+const packageRoot = new URL("..", import.meta.url);
+const tempDirectory = mkdtempSync(join(tmpdir(), "keyquest-package-smoke-"));
+let tarballPath;
+
+try {
+  exec("npm", ["run", "build"], { cwd: packageRoot });
+  const packOutput = exec("npm", ["pack", "--json"], { cwd: packageRoot });
+  const packedFiles = JSON.parse(packOutput);
+  const firstPack = Array.isArray(packedFiles) ? packedFiles[0] : undefined;
+  if (firstPack === undefined || typeof firstPack.filename !== "string") {
+    throw new Error("npm pack did not report a tarball filename");
+  }
+
+  tarballPath = new URL(firstPack.filename, packageRoot).pathname;
+  exec("npm", ["install", tarballPath], { cwd: tempDirectory });
+
+  const binaryPath = join(tempDirectory, "node_modules", ".bin", "keyquest");
+  const versionOutput = exec(binaryPath, ["--version"], { cwd: tempDirectory }).trim();
+  if (!/^keyquest \d+\.\d+\.\d+/.test(versionOutput)) {
+    throw new Error(`Unexpected --version output: ${versionOutput}`);
+  }
+
+  const helpOutput = exec(binaryPath, ["--help"], { cwd: tempDirectory });
+  if (!helpOutput.includes("Usage:") || !helpOutput.includes("--lesson-pack <path>")) {
+    throw new Error("--help output did not include expected usage text");
+  }
+
+  console.log(`Package smoke passed: ${versionOutput}`);
+} finally {
+  rmSync(tempDirectory, { recursive: true, force: true });
+  if (tarballPath !== undefined) {
+    unlinkSync(tarballPath);
+  }
+}
+
+function exec(command, args, options) {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+}


### PR DESCRIPTION
## Summary
- Replace the dry-run-only package smoke script with a tarball install smoke check.
- Run installed `keyquest --version` and `keyquest --help` from a temporary project.
- Update publishing docs and release-readiness tracking.

## Test plan
- [x] npm run verify
- [x] npm run package:smoke

Closes #159

Made with [Cursor](https://cursor.com)