### PR TITLE
Implement minimal Load Game action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ drafts from git history.
 
 ## Unreleased
 
+- Added a minimal Load Game action for the current saved journey.
 - Added a README terminal transcript preview for the public CLI flow.
 - Strengthened `npm run package:smoke` to install the packed tarball and run the CLI.
 - Added an in-game Help screen from the title menu.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -173,6 +173,7 @@ Goal: publish a useful open-source CLI.
 - `npx keyquest` smoke test
 - CLI help and version output
 - In-game help menu for first-time players
+- Minimal current-slot Load Game action
 - README with screenshots or terminal recording
 - README terminal transcript preview
 - npm package metadata

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -80,3 +80,4 @@
 - [x] Add in-game help menu.
 - [x] Strengthen npm package tarball smoke test.
 - [x] Add README terminal transcript.
+- [x] Implement minimal Load Game current-slot action.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -68,6 +68,55 @@ describe("runApp", () => {
     expect(output.text()).toContain("Session Result");
   });
 
+  it("shows a notice when loading before any journey is saved", async () => {
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "normal",
+      saveDirectory: await createTempDirectory(),
+      textInput: createQueuedTextInput(["5", "1", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+
+    expect(output.text()).toContain("No saved journey is available yet");
+    expect(output.text()).toContain("Session Result");
+  });
+
+  it("loads the current saved journey from the title menu", async () => {
+    const directory = await createTempDirectory();
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["1", "f j", "ff jj", "fj jf"]),
+      textOutput: createMemoryOutput(),
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+    const output = createMemoryOutput();
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["5", "f j", "ff jj", "fj jf"]),
+      textOutput: output,
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-02T00:00:00.000Z"),
+      completedAt: new Date("2026-01-02T00:00:20.000Z"),
+    });
+
+    const save = await createSaveStore({ mode: "development", directory }).loadOrCreate(
+      new Date("2026-01-02T00:01:00.000Z"),
+    );
+    expect(output.text()).not.toContain("No saved journey is available yet");
+    expect(save.progress.sessions).toHaveLength(2);
+    expect(save.journey.day).toBe(3);
+  });
+
   it("shows Gatekeeper clear and Day 8 advancement after Day 7", async () => {
     const directory = await createTempDirectory();
     const now = new Date("2026-01-01T00:00:00.000Z");
@@ -566,7 +615,7 @@ describe("runApp", () => {
     expect(output.text()).toContain("セッション結果");
   });
 
-  it("explains that load game is planned and returns to the title menu", async () => {
+  it("returns to the title when loading without a saved journey", async () => {
     const output = createMemoryOutput();
     await runApp({
       mode: "normal",
@@ -579,7 +628,7 @@ describe("runApp", () => {
       completedAt: new Date("2026-01-01T00:00:20.000Z"),
     });
 
-    expect(output.text()).toContain("Load Game will open save slots later");
+    expect(output.text()).toContain("No saved journey is available yet");
     expect(output.text()).toContain("Session Result");
   });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -330,8 +330,12 @@ async function runTitleMenu(options: {
     }
 
     if (action === "loadGame") {
-      notice = translator.t("title.menu.loadUnavailable");
-      continue;
+      if (save.progress.sessions.length === 0) {
+        notice = translator.t("title.menu.loadUnavailable");
+        continue;
+      }
+
+      return { save, action: "start" };
     }
 
     if (action === "help") {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -23,7 +23,7 @@ const EN_MESSAGES = {
   "title.menu.start": "Start",
   "title.menu.prompt": "Choose: ",
   "title.menu.planned": "planned",
-  "title.menu.loadUnavailable": "Load Game will open save slots later. Use Continue for now.",
+  "title.menu.loadUnavailable": "No saved journey is available yet. Choose Start first.",
   "help.heading": "How to Play",
   "help.daily": "Play one short daily session to advance the 90-day journey.",
   "help.review": "Review Weak Keys creates focused practice from your recent mistakes.",
@@ -145,8 +145,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "スタート",
     "title.menu.prompt": "選択: ",
     "title.menu.planned": "予定",
-    "title.menu.loadUnavailable":
-      "ロードゲームは今後セーブスロットに対応します。今は「つづきから」を使ってください。",
+    "title.menu.loadUnavailable": "保存済みの旅はまだありません。まずスタートを選んでください。",
     "help.heading": "遊び方",
     "help.daily": "短いデイリーセッションを1回遊ぶと、90日間の旅が進みます。",
     "help.review": "弱点キー復習は、直近のミスから集中練習を作ります。",
@@ -266,7 +265,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "开始",
     "title.menu.prompt": "请选择: ",
     "title.menu.planned": "计划中",
-    "title.menu.loadUnavailable": "读取游戏稍后会支持存档槽。现在请使用继续。",
+    "title.menu.loadUnavailable": "还没有可读取的旅程。请先选择开始。",
     "help.heading": "玩法说明",
     "help.daily": "每天完成一次短练习，就能推进 90 天旅程。",
     "help.review": "复习弱键会根据最近的错误生成集中练习。",
@@ -381,8 +380,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "시작",
     "title.menu.prompt": "선택: ",
     "title.menu.planned": "예정",
-    "title.menu.loadUnavailable":
-      "불러오기는 나중에 저장 슬롯으로 열립니다. 지금은 계속하기를 사용하세요.",
+    "title.menu.loadUnavailable": "아직 불러올 여정이 없습니다. 먼저 시작을 선택하세요.",
     "help.heading": "플레이 방법",
     "help.daily": "짧은 일일 세션을 한 번 플레이하면 90일 여정이 진행됩니다.",
     "help.review": "약한 키 복습은 최근 실수에서 집중 연습을 만듭니다.",
@@ -498,8 +496,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "Empezar",
     "title.menu.prompt": "Elige: ",
     "title.menu.planned": "planeado",
-    "title.menu.loadUnavailable":
-      "Cargar partida abrirá ranuras de guardado más adelante. Usa Continuar por ahora.",
+    "title.menu.loadUnavailable": "Aún no hay viaje guardado. Elige Empezar primero.",
     "help.heading": "Cómo jugar",
     "help.daily": "Juega una sesión diaria corta para avanzar en el viaje de 90 días.",
     "help.review":
@@ -623,8 +620,7 @@ const CATALOGS: Readonly<Record<LocaleId, Readonly<Partial<Record<MessageKey, st
     "title.menu.start": "Começar",
     "title.menu.prompt": "Escolha: ",
     "title.menu.planned": "planejado",
-    "title.menu.loadUnavailable":
-      "Carregar jogo abrirá slots de save mais tarde. Use Continuar por enquanto.",
+    "title.menu.loadUnavailable": "Ainda não há jornada salva. Escolha Começar primeiro.",
     "help.heading": "Como jogar",
     "help.daily": "Jogue uma sessão diária curta para avançar na jornada de 90 dias.",
     "help.review": "Revisar teclas fracas cria prática focada a partir dos seus erros recentes.",

--- a/src/menu/title-menu.test.ts
+++ b/src/menu/title-menu.test.ts
@@ -18,7 +18,8 @@ describe("title menu", () => {
     expect(lines.join("\n")).toContain("Start");
     expect(lines.join("\n")).toContain("Review Weak Keys");
     expect(lines.join("\n")).toContain("New Game");
-    expect(lines.join("\n")).toContain("Load Game (planned)");
+    expect(lines.join("\n")).toContain("Load Game");
+    expect(lines.join("\n")).not.toContain("Load Game (planned)");
     expect(lines.join("\n")).toContain("Help");
   });
 

--- a/src/menu/title-menu.ts
+++ b/src/menu/title-menu.ts
@@ -25,7 +25,7 @@ export function renderTitleMenu(save: KeyQuestSave, translator: Translator): rea
     `2. ${translator.t("title.menu.review")}`,
     `3. ${translator.t("title.menu.options")}`,
     `4. ${translator.t("title.menu.newGame")}`,
-    `5. ${translator.t("title.menu.loadGame")} (${translator.t("title.menu.planned")})`,
+    `5. ${translator.t("title.menu.loadGame")}`,
     `6. ${translator.t("title.menu.help")}`,
   ];
 }


### PR DESCRIPTION
## Summary
- Remove the planned marker from Load Game in the title menu.
- Start the current saved journey when Load Game is selected with existing progress.
- Show a localized notice and return to title when no saved journey exists yet.

## Test plan
- [x] npm run verify

Closes #163

Made with [Cursor](https://cursor.com)