### PR TITLE
Preserve settings when starting New Game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ drafts from git history.
 
 ## Unreleased
 
+- Fixed New Game so it preserves option settings such as the selected language.
 - Added New Game confirmation before replacing an existing saved journey.
 - Added a minimal Load Game action for the current saved journey.
 - Added a README terminal transcript preview for the public CLI flow.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -82,3 +82,4 @@
 - [x] Add README terminal transcript.
 - [x] Implement minimal Load Game current-slot action.
 - [x] Confirm New Game before replacing existing progress.
+- [x] Preserve options when starting New Game.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -728,6 +728,37 @@ describe("runApp", () => {
     expect(save.profile.createdAt).toBe("2026-01-02T00:00:00.000Z");
   });
 
+  it("preserves options when New Game replaces progress", async () => {
+    const directory = await createTempDirectory();
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["3", "2", "1", "f j", "ff jj", "fj jf"]),
+      textOutput: createMemoryOutput(),
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-01T00:00:20.000Z"),
+    });
+    await runApp({
+      mode: "development",
+      saveDirectory: directory,
+      textInput: createQueuedTextInput(["4", "yes", "f j", "ff jj", "fj jf"]),
+      textOutput: createMemoryOutput(),
+      lesson: createTestLesson(),
+      lessonPath: undefined,
+      now: new Date("2026-01-02T00:00:00.000Z"),
+      completedAt: new Date("2026-01-02T00:00:20.000Z"),
+    });
+
+    const save = await createSaveStore({ mode: "development", directory }).loadOrCreate(
+      new Date("2026-01-02T00:01:00.000Z"),
+    );
+    expect(save.settings.locale).toBe("ja");
+    expect(save.progress.sessions).toHaveLength(1);
+    expect(save.profile.createdAt).toBe("2026-01-02T00:00:00.000Z");
+  });
+
   it("keeps the current save when New Game confirmation is cancelled", async () => {
     const directory = await createTempDirectory();
     await runApp({

--- a/src/app.ts
+++ b/src/app.ts
@@ -334,7 +334,10 @@ async function runTitleMenu(options: {
         }
       }
 
-      const newSave = createNewSave(options.now, options.mode);
+      const newSave = {
+        ...createNewSave(options.now, options.mode),
+        settings: save.settings,
+      };
       await options.writeSave(newSave);
       return { save: newSave, action: "start" };
     }


### PR DESCRIPTION
## Summary
- Preserve existing user settings when New Game replaces gameplay progress.
- Add regression coverage that language selection survives New Game.
- Update changelog and TODO tracking.

## Test plan
- [x] npm run verify

Closes #167

Made with [Cursor](https://cursor.com)