### PR TITLE
Extend quest arc map through Day 90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ drafts from git history.
 
 ## Unreleased
 
+- Extended the typed quest arc map with planned arcs through Day 90.
 - Added a Journey progress screen from the title menu with current day, arc, weekly trial, and ending progress.
 - Added interactive menu navigation with `j`/`k`, arrow keys, Enter, and Space in TTY screen mode.
 - Added an in-practice options shortcut so players can change language during a run.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -139,6 +139,7 @@ Goal: shape daily practice into a 90-day fantasy journey.
 - 7-day training cycle with weekly boss quests
 - Typed quest arc map and weekly trial rules for implemented arcs
 - 90-day story map and ending
+- Planned typed quest arcs through Day 90
 - Quest map and progression
 - Documented adventure progression model for daily quests, weekly arcs, and
   weak-key review

--- a/docs/PROGRESSION_DESIGN.md
+++ b/docs/PROGRESSION_DESIGN.md
@@ -64,6 +64,22 @@ Use a 7-day training cycle.
 Boss quests should test the week's skills, not surprise the player with unrelated
 difficulty.
 
+## Implemented 90-Day Map Skeleton
+
+The typed quest map now covers the full 90-day promise. Days 1-28 are backed by
+bundled lessons, while Days 29-90 are planned arcs that give future content stable
+destinations:
+
+- Ashen Forge: Shift keys and capital letters.
+- Windspire: speed control and rhythm.
+- Clockwork Citadel: programmer pairs and brackets.
+- Starfall Library: symbols, operators, and code-like flow.
+- Dragon Spine: accuracy under speed pressure.
+- Moonlit Labyrinth: weak-key recovery and calm correction.
+- Obsidian Throne: mixed punctuation and long-form focus.
+- Dawn Citadel: full-keyboard mastery review.
+- Final Gate: final integrated typing quest.
+
 ## Incremental Systems
 
 Incremental growth should be steady, legible, and mostly deterministic.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,6 +31,7 @@ Goal: turn the playable loop into a training journey.
 
 - 7-day weekly training rhythm.
 - 90-day journey map with classic fantasy chapters.
+- Planned typed quest arcs through Day 90.
 - Skill tracks for rows, Shift, numbers, symbols, and accuracy.
 - Weak-key detection and review quests.
 - Achievement engine and first achievement set.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -86,3 +86,4 @@
 - [x] Add interactive `j`/`k` menu navigation for TTY mode.
 - [x] Allow options changes during practice.
 - [x] Add a Journey progress screen with current day, arc, weekly trial, and ending progress.
+- [x] Extend the typed quest arc map with planned arcs through Day 90.

--- a/src/menu/title-menu.test.ts
+++ b/src/menu/title-menu.test.ts
@@ -64,6 +64,22 @@ describe("title menu", () => {
     expect(lines.join("\n")).toContain("76 days remain");
   });
 
+  it("renders final journey arc progress", () => {
+    const save = {
+      ...createNewSave(new Date("2026-01-01T00:00:00.000Z"), "normal"),
+      journey: {
+        day: 90,
+        chapter: 13,
+        storyFlag: "noviceHallStarted" as const,
+      },
+    };
+    const lines = renderJourneyProgress(save, createTranslator("en"));
+
+    expect(lines.join("\n")).toContain("Arc: Final Gate");
+    expect(lines.join("\n")).toContain("Weekly Trial: Last Spell Trial on Day 90");
+    expect(lines.join("\n")).toContain("The final gate is open");
+  });
+
   it("renders and parses language choices", () => {
     const lines = renderLanguageOptions("en", createTranslator("en"));
 

--- a/src/menu/title-menu.ts
+++ b/src/menu/title-menu.ts
@@ -7,7 +7,7 @@ import {
   type Translator,
 } from "../i18n/messages.js";
 import { JOURNEY_ENDING_DAY, getJourneyEndingState } from "../quest/ending.js";
-import { QUEST_ARCS } from "../quest/map.js";
+import { getDisplayQuestArcForDay } from "../quest/map.js";
 import type { KeyQuestSave } from "../save/model.js";
 import type { InteractiveMenuItem } from "./interactive-menu.js";
 
@@ -108,7 +108,7 @@ export function renderJourneyProgress(
   save: KeyQuestSave,
   translator: Translator,
 ): readonly string[] {
-  const arc = getDisplayQuestArc(save.journey.day);
+  const arc = getDisplayQuestArcForDay(save.journey.day);
   const endingState = getJourneyEndingState(save);
   const endingLine =
     endingState.status === "inProgress"
@@ -188,18 +188,4 @@ export function parseLocaleChoice(input: string, currentLocale: LocaleId): Local
 
 export function createMenuTranslator(save: KeyQuestSave): Translator {
   return createTranslator(save.settings.locale);
-}
-
-function getDisplayQuestArc(day: number): (typeof QUEST_ARCS)[number] {
-  const arc = QUEST_ARCS.find((candidate) => day >= candidate.startDay && day <= candidate.endDay);
-  if (arc !== undefined) {
-    return arc;
-  }
-
-  const finalArc = QUEST_ARCS[QUEST_ARCS.length - 1];
-  if (finalArc === undefined) {
-    throw new Error("At least one quest arc is required");
-  }
-
-  return finalArc;
 }

--- a/src/quest/map.test.ts
+++ b/src/quest/map.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getDisplayQuestArcForDay,
   getQuestArcForDay,
   getWeeklyTrialRuleForDay,
   isWeeklyTrialDay,
@@ -15,11 +16,23 @@ describe("quest map", () => {
       "meadowRoad",
       "riverGate",
       "lanternKeep",
+      "ashenForge",
+      "windspire",
+      "clockworkCitadel",
+      "starfallLibrary",
+      "dragonSpine",
+      "moonlitLabyrinth",
+      "obsidianThrone",
+      "dawnCitadel",
+      "finalGate",
     ]);
     expect(getQuestArcForDay(1).id).toBe("noviceHall");
     expect(getQuestArcForDay(8).id).toBe("meadowRoad");
     expect(getQuestArcForDay(15).id).toBe("riverGate");
     expect(getQuestArcForDay(28).id).toBe("lanternKeep");
+    expect(getQuestArcForDay(29).id).toBe("ashenForge");
+    expect(getQuestArcForDay(49).id).toBe("clockworkCitadel");
+    expect(getQuestArcForDay(90).id).toBe("finalGate");
   });
 
   it("identifies weekly trial days and prompt counts", () => {
@@ -50,11 +63,29 @@ describe("quest map", () => {
       },
     ]);
     expect(isWeeklyTrialDay(7)).toBe(true);
+    expect(isWeeklyTrialDay(90)).toBe(true);
     expect(isWeeklyTrialDay(22)).toBe(false);
   });
 
-  it("rejects days without implemented quest arcs", () => {
+  it("identifies planned future weekly trials", () => {
+    expect(getWeeklyTrialRuleForDay(35)).toEqual({
+      day: 35,
+      title: "Anvil Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    });
+    expect(getWeeklyTrialRuleForDay(90)).toEqual({
+      day: 90,
+      title: "Last Spell Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    });
+  });
+
+  it("keeps post-game display anchored to the final arc", () => {
+    expect(getDisplayQuestArcForDay(91).id).toBe("finalGate");
+  });
+
+  it("rejects days outside the 90-day quest map", () => {
     expect(() => getQuestArcForDay(0)).toThrow("No quest arc");
-    expect(() => getQuestArcForDay(29)).toThrow("No quest arc");
+    expect(() => getQuestArcForDay(91)).toThrow("No quest arc");
   });
 });

--- a/src/quest/map.ts
+++ b/src/quest/map.ts
@@ -6,7 +6,20 @@ import {
 } from "../lessons/manifest.js";
 import type { TitleRewardId } from "../save/model.js";
 
-export type QuestArcId = "noviceHall" | "meadowRoad" | "riverGate" | "lanternKeep";
+export type QuestArcId =
+  | "noviceHall"
+  | "meadowRoad"
+  | "riverGate"
+  | "lanternKeep"
+  | "ashenForge"
+  | "windspire"
+  | "clockworkCitadel"
+  | "starfallLibrary"
+  | "dragonSpine"
+  | "moonlitLabyrinth"
+  | "obsidianThrone"
+  | "dawnCitadel"
+  | "finalGate";
 
 export type QuestArc = {
   readonly id: QuestArcId;
@@ -21,7 +34,7 @@ export type WeeklyTrialRule = {
   readonly day: number;
   readonly title: string;
   readonly sessionPromptCount: number;
-  readonly rewardTitleId: TitleRewardId;
+  readonly rewardTitleId?: TitleRewardId;
 };
 
 export const WEEKLY_TRIAL_PROMPT_COUNT = 4;
@@ -79,6 +92,114 @@ export const QUEST_ARCS: readonly QuestArc[] = [
       rewardTitleId: "lanternKeepBeacon",
     },
   },
+  {
+    id: "ashenForge",
+    title: "Ashen Forge",
+    startDay: LANTERN_KEEP_FINAL_DAY + 1,
+    endDay: 35,
+    theme: "Shift keys and capital letters",
+    trial: {
+      day: 35,
+      title: "Anvil Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "windspire",
+    title: "Windspire",
+    startDay: 36,
+    endDay: 42,
+    theme: "speed control and rhythm",
+    trial: {
+      day: 42,
+      title: "Gale Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "clockworkCitadel",
+    title: "Clockwork Citadel",
+    startDay: 43,
+    endDay: 49,
+    theme: "programmer pairs and brackets",
+    trial: {
+      day: 49,
+      title: "Gearheart Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "starfallLibrary",
+    title: "Starfall Library",
+    startDay: 50,
+    endDay: 56,
+    theme: "symbols, operators, and code-like flow",
+    trial: {
+      day: 56,
+      title: "Archivist Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "dragonSpine",
+    title: "Dragon Spine",
+    startDay: 57,
+    endDay: 63,
+    theme: "accuracy under speed pressure",
+    trial: {
+      day: 63,
+      title: "Wyrm Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "moonlitLabyrinth",
+    title: "Moonlit Labyrinth",
+    startDay: 64,
+    endDay: 70,
+    theme: "weak-key recovery and calm correction",
+    trial: {
+      day: 70,
+      title: "Minotaur Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "obsidianThrone",
+    title: "Obsidian Throne",
+    startDay: 71,
+    endDay: 77,
+    theme: "mixed punctuation and long-form focus",
+    trial: {
+      day: 77,
+      title: "Crown Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "dawnCitadel",
+    title: "Dawn Citadel",
+    startDay: 78,
+    endDay: 84,
+    theme: "full-keyboard mastery review",
+    trial: {
+      day: 84,
+      title: "Dawn Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
+  {
+    id: "finalGate",
+    title: "Final Gate",
+    startDay: 85,
+    endDay: 90,
+    theme: "final integrated typing quest",
+    trial: {
+      day: 90,
+      title: "Last Spell Trial",
+      sessionPromptCount: WEEKLY_TRIAL_PROMPT_COUNT,
+    },
+  },
 ];
 
 export function getQuestArcForDay(day: number): QuestArc {
@@ -88,6 +209,24 @@ export function getQuestArcForDay(day: number): QuestArc {
   }
 
   return arc;
+}
+
+export function getDisplayQuestArcForDay(day: number): QuestArc {
+  if (day < 1) {
+    return getQuestArcForDay(day);
+  }
+
+  const arc = QUEST_ARCS.find((candidate) => day >= candidate.startDay && day <= candidate.endDay);
+  if (arc !== undefined) {
+    return arc;
+  }
+
+  const finalArc = QUEST_ARCS[QUEST_ARCS.length - 1];
+  if (finalArc === undefined) {
+    throw new Error("At least one quest arc is required");
+  }
+
+  return finalArc;
 }
 
 export function getWeeklyTrialRuleForDay(day: number): WeeklyTrialRule | undefined {

--- a/src/scenes/scenes.ts
+++ b/src/scenes/scenes.ts
@@ -20,7 +20,7 @@ import {
 } from "../lessons/manifest.js";
 import { EQUIPMENT_UPGRADES, getEquipmentUpgradeLevel } from "../quest/equipment.js";
 import { getJourneyEndingState } from "../quest/ending.js";
-import { getQuestArcForDay } from "../quest/map.js";
+import { getDisplayQuestArcForDay } from "../quest/map.js";
 import { getQuestModifierForDay } from "../quest/modifiers.js";
 import { createInitialQuestResources } from "../save/model.js";
 import { styleText } from "../terminal/ansi.js";
@@ -71,7 +71,7 @@ export const statusScene: Scene = {
       .map((skill) => `${skill.id} Lv.${skill.level}`)
       .join(" / ");
     const resources = context.save.progress.resources ?? createInitialQuestResources();
-    const arc = getQuestArcForDay(context.save.journey.day);
+    const arc = getDisplayQuestArcForDay(context.save.journey.day);
     const modifier = getQuestModifierForDay(context.save.journey.day);
 
     return {


### PR DESCRIPTION
## Summary
- Extend the typed quest arc map with planned arcs and weekly trials through Day 90.
- Add a display-safe arc resolver for post-game status/Journey views.
- Update Journey/map tests and progression docs.

## Test plan
- [x] npm run verify

Closes #173

Made with [Cursor](https://cursor.com)