### PR TITLE
Finalize release readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ drafts from git history.
 
 ## Unreleased
 
+- Added `npm run release:check` and a final release checklist.
+- Strengthened package smoke checks to validate npm tarball file boundaries.
 - Added title-menu record screens for resources, achievements, and titles.
 - Added post-game goal details to the Journey progress screen.
 - Extended the typed quest arc map with planned arcs through Day 90.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm run verify
 Check the package contents before publishing:
 
 ```bash
-npm run package:smoke
+npm run release:check
 ```
 
 ## Project Management
@@ -144,6 +144,7 @@ This project is managed with GitHub Issues and local Markdown planning docs.
 - Localization: `docs/LOCALIZATION.md`
 - Save data: `docs/SAVE_DATA.md`
 - Publishing: `docs/PUBLISHING.md`
+- Release checklist: `docs/RELEASE_CHECKLIST.md`
 - Testing strategy: `docs/TESTING_STRATEGY.md`
 - Development philosophy and policy: `docs/DEVELOPMENT.md`
 - Coding standards: `docs/CODING_STANDARDS.md`

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -186,6 +186,8 @@ Goal: publish a useful open-source CLI.
 - README with screenshots or terminal recording
 - README terminal transcript preview
 - npm package metadata
+- Single-command release check
+- Final release checklist documentation
 - npm package smoke script and publishing checklist
 - Tarball install smoke for packaged CLI
 - Supported locales validated

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -10,14 +10,14 @@ is ready.
 Before publishing:
 
 ```sh
-npm run verify
-npm run release:notes
-npm run package:smoke
+npm run release:check
 ```
 
-`package:smoke` builds `dist/`, creates a local npm tarball, installs it into a
-temporary directory, and runs `keyquest --version` plus `keyquest --help` from the
-installed package.
+`release:check` runs verification, release-note draft generation, and the package
+smoke test.
+`package:smoke` builds `dist/`, creates a local npm tarball, checks package file
+boundaries, installs it into a temporary directory, and runs `keyquest --version`
+plus `keyquest --help` from the installed package.
 `release:notes` prints a draft from git history so `CHANGELOG.md` and the GitHub
 release can stay aligned.
 
@@ -39,7 +39,8 @@ published package unless they become part of the public user experience.
 2. Update package version.
 3. Run `npm run release:notes`.
 4. Update `CHANGELOG.md` from the generated draft.
-5. Run `npm run verify`.
-6. Run `npm run package:smoke` and confirm the installed CLI smoke passes.
-7. Publish with npm using the intended access level.
-8. Create a GitHub release that links the changelog entry.
+5. Run `npm run release:check` and confirm the installed CLI smoke passes.
+6. Publish with npm using the intended access level.
+7. Create a GitHub release that links the changelog entry.
+
+For the final manual pass, use `docs/RELEASE_CHECKLIST.md`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,34 @@
+# Release Checklist
+
+Use this checklist before publishing a public KeyQuest release.
+
+## Automated Checks
+
+Run the full release check:
+
+```sh
+npm run release:check
+```
+
+This runs type checking, linting, formatting checks, bundled lesson validation,
+unit tests, release-note draft generation, package build, tarball inspection, and
+installed CLI smoke checks for `--version` and `--help`.
+
+## Manual Checks
+
+- Confirm `main` is synced with `origin/main`.
+- Confirm the version in `package.json` is the intended release version.
+- Review the `npm run release:notes` draft against `CHANGELOG.md`.
+- Run the CLI manually in a real terminal and complete a short session.
+- Check the title-menu flows: Help, Journey, Resources, Achievements, Titles,
+  Options, Load Game, and New Game confirmation.
+- Confirm `--no-color` and `--reduced-motion` remain readable.
+- Confirm no local save data, development scripts, source files, tests, or docs
+  are included in the npm tarball.
+
+## Publish
+
+1. Publish to npm with the intended access level.
+2. Create a GitHub release for the same version.
+3. Paste the reviewed release notes into the GitHub release.
+4. Verify the published package with `npx keyquest --version`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,7 @@ Goal: make KeyQuest easy to try and trustworthy as an open-source CLI.
 - `npx keyquest` works cleanly.
 - README explains the 90-day premise and shows the CLI flow.
 - Release checklist exists.
+- A single release check command verifies the package before publishing.
 - Package metadata is ready for npm.
 - Supported locales pass catalog validation.
 - Smoke tests cover install, start, and a minimal session path.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -92,3 +92,6 @@
 - [x] Add a Titles record screen from the title menu.
 - [x] Show post-game goal details from the Journey screen.
 - [x] Integrate progress record screens into title navigation.
+- [x] Add a single `npm run release:check` command.
+- [x] Add final release checklist documentation.
+- [x] Validate npm tarball file boundaries in package smoke.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:watch": "vitest",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run lessons:validate && npm run test",
     "release:notes": "node scripts/release-notes.mjs",
+    "release:check": "npm run verify && npm run release:notes && npm run package:smoke",
     "package:smoke": "node scripts/package-smoke.mjs",
     "prepublishOnly": "npm run verify && npm run build"
   },

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -11,6 +11,7 @@ const tempDirectory = mkdtempSync(join(tmpdir(), "keyquest-package-smoke-"));
 let tarballPath;
 
 try {
+  rmSync(new URL("../dist", import.meta.url), { recursive: true, force: true });
   exec("npm", ["run", "build"], { cwd: packageRoot });
   const packOutput = exec("npm", ["pack", "--json"], { cwd: packageRoot });
   const packedFiles = JSON.parse(packOutput);
@@ -18,6 +19,7 @@ try {
   if (firstPack === undefined || typeof firstPack.filename !== "string") {
     throw new Error("npm pack did not report a tarball filename");
   }
+  assertPackageFiles(firstPack);
 
   tarballPath = new URL(firstPack.filename, packageRoot).pathname;
   exec("npm", ["install", tarballPath], { cwd: tempDirectory });
@@ -47,4 +49,36 @@ function exec(command, args, options) {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "inherit"],
   });
+}
+
+function assertPackageFiles(pack) {
+  if (!Array.isArray(pack.files)) {
+    throw new Error("npm pack did not report package files");
+  }
+
+  const paths = pack.files.map((file) => file.path);
+  const requiredPrefixes = ["dist/", "lessons/"];
+  const requiredFiles = ["README.md", "LICENSE", "package.json"];
+  for (const requiredFile of requiredFiles) {
+    if (!paths.includes(requiredFile)) {
+      throw new Error(`Package tarball is missing ${requiredFile}`);
+    }
+  }
+
+  for (const requiredPrefix of requiredPrefixes) {
+    if (!paths.some((path) => path.startsWith(requiredPrefix))) {
+      throw new Error(`Package tarball is missing ${requiredPrefix}`);
+    }
+  }
+
+  const forbiddenPrefixes = ["src/", "docs/", "test/", "scripts/"];
+  const forbiddenSuffixes = [".test.js", ".test.ts", ".map"];
+  const forbiddenPath = paths.find(
+    (path) =>
+      forbiddenPrefixes.some((prefix) => path.startsWith(prefix)) ||
+      forbiddenSuffixes.some((suffix) => path.endsWith(suffix)),
+  );
+  if (forbiddenPath !== undefined) {
+    throw new Error(`Package tarball includes development-only file: ${forbiddenPath}`);
+  }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Add `npm run release:check` to run verify, release-note drafting, and package smoke together.
- Add a final release checklist for manual pre-publish checks.
- Strengthen package smoke to clean build output and validate npm tarball boundaries.
- Disable build sourcemaps so published tarballs do not include `.map` files.

## Test plan
- [x] npm run verify
- [x] npm run package:smoke
- [x] npm run release:check

Closes #177

Made with [Cursor](https://cursor.com)